### PR TITLE
Add --version flag to the CLI

### DIFF
--- a/cmd/workflowy/main.go
+++ b/cmd/workflowy/main.go
@@ -17,6 +17,7 @@ var (
 func main() {
 	cmd := &cli.Command{
 		Name:                  "workflowy",
+		Version:               version,
 		Usage:                 "Interact with Workflowy API",
 		UseShortOptionHandling: true,
 		Description: `Retieve, create and update nodes.  Generate usage reports and upload them to Workflowy.


### PR DESCRIPTION
The `version` subcommand already exists for detailed version info (version, commit hash, build date), but there was no `--version` flag on the root command.

Setting the `Version` field on the root `cli.Command` lets [urfave/cli](https://github.com/mholzen/workflowy/blob/5f3b1839adc5889dbac249e4bbe52589c16f3fa9/go.mod#L8) automatically provide a `--version` / `-v` flag, which is the conventional way for CLI tools to report their version.

Fixes #5.
