### PR TITLE
Add API selection and on-demand mirror traversal foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Get your API key at https://workflowy.com/api-key/
 
 ```bash
 # Get the top-level nodes from production (default)
-workflowy get --depth=0
+workflowy get --depth=1
 
 # Read from Workflowy's beta deployment
-workflowy get --depth=0 --api=beta
+workflowy get --depth=1 --api=beta
 
 # Generate a report showing where most of your nodes are
 workflowy report count | pbcopy   # paste directly into Workflowy!

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ Get your API key at https://workflowy.com/api-key/
 ### Run Your First Command
 
 ```bash
-# Get the top-level nodes, and nodes two levels deep
-workflowy get
+# Get the top-level nodes from production (default)
+workflowy get --depth=0
+
+# Read from Workflowy's beta deployment
+workflowy get --depth=0 --api=beta
 
 # Generate a report showing where most of your nodes are
 workflowy report count | pbcopy   # paste directly into Workflowy!
@@ -59,6 +62,9 @@ Use `pbcopy` on macOS, `clip` on Windows, `wl-copy` on Linux, or `xclip` for X11
 
 ```bash
 claude mcp add --transport=stdio workflowy -- workflowy mcp --expose=all
+
+# Use beta as the MCP server default
+claude mcp add --transport=stdio workflowy-beta -- workflowy mcp --expose=all --api=beta
 ```
 
 Remove `—expose=all` to limit to read-only tools.
@@ -80,6 +86,8 @@ Add to your configuration file:
   }
 }
 ```
+
+Add `"--api=beta"` to `args` to make beta the server default.
 
 Restart Claude Desktop and start asking Claude to work with your Workflowy!
 
@@ -189,6 +197,12 @@ workflowy report modified --top-n 50
 workflowy report mirrors --top-n 20
 ```
 
+## API Deployment
+
+Use `--api=production|beta` to choose the Workflowy deployment. Production is the default; beta is opt-in. The beta API currently exposes mirror metadata such as `data.mirror.origin_id` that the production API does not expose.
+
+`--api` and `--method` are independent: `--api` chooses the deployment, while `--method=get|export|backup` chooses how data is read or validated. A command can read from a local backup and still use the selected API for writes, such as `workflowy report count --method=backup --upload --api=beta`.
+
 ## Data Access Methods
 
 Choose the best method for your use case:
@@ -200,6 +214,11 @@ Choose the best method for your use case:
 | `--method=backup` | Fastest | Stale | **Yes** | Bulk operations |
 
 *Cached after first fetch
+
+Export caches are isolated by deployment:
+
+- Production: `~/.workflowy/export-cache.json`
+- Beta: `~/.workflowy/export-cache-beta.json`
 
 ### Offline Mode with Dropbox Backup
 

--- a/cmd/workflowy/backup_api_test.go
+++ b/cmd/workflowy/backup_api_test.go
@@ -42,6 +42,10 @@ func (client *networkRejectingClient) ExportNodesWithCache(context.Context, bool
 	return nil, client.rejectNetworkCall()
 }
 
+func (client *networkRejectingClient) ListChildrenRecursiveWithOptions(context.Context, string, workflowy.RecursiveFetchOptions) (*workflowy.RecursiveFetchResult, error) {
+	return nil, client.rejectNetworkCall()
+}
+
 func (client *networkRejectingClient) DeleteNode(context.Context, string) (*workflowy.UpdateNodeResponse, error) {
 	client.mutations++
 	return &workflowy.UpdateNodeResponse{}, nil

--- a/cmd/workflowy/backup_api_test.go
+++ b/cmd/workflowy/backup_api_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+const (
+	backupRootID = "11111111-1111-1111-1111-aaaaaaaaaaaa"
+	backupItemID = "22222222-2222-2222-2222-bbbbbbbbbbbb"
+)
+
+type networkRejectingClient struct {
+	MockClient
+	networkCalls int
+	mutations    int
+}
+
+func (client *networkRejectingClient) rejectNetworkCall() error {
+	client.networkCalls++
+	return fmt.Errorf("unexpected network call")
+}
+
+func (client *networkRejectingClient) ListTargets(context.Context) (*workflowy.ListTargetsResponse, error) {
+	return nil, client.rejectNetworkCall()
+}
+
+func (client *networkRejectingClient) GetItem(context.Context, string) (*workflowy.Item, error) {
+	return nil, client.rejectNetworkCall()
+}
+
+func (client *networkRejectingClient) ExportNodesWithCache(context.Context, bool) (*workflowy.ExportNodesResponse, error) {
+	return nil, client.rejectNetworkCall()
+}
+
+func (client *networkRejectingClient) DeleteNode(context.Context, string) (*workflowy.UpdateNodeResponse, error) {
+	client.mutations++
+	return &workflowy.UpdateNodeResponse{}, nil
+}
+
+func (client *networkRejectingClient) CompleteNode(context.Context, string) (*workflowy.UpdateNodeResponse, error) {
+	client.mutations++
+	return &workflowy.UpdateNodeResponse{}, nil
+}
+
+func (client *networkRejectingClient) UncompleteNode(context.Context, string) (*workflowy.UpdateNodeResponse, error) {
+	client.mutations++
+	return &workflowy.UpdateNodeResponse{}, nil
+}
+
+func TestGetBackupResolvesIDsAndRestrictionsWithoutNetwork(t *testing.T) {
+	backupFile := writeCommandBackup(t)
+	client := &networkRejectingClient{}
+	command := getGetCommandWithClientProvider(withMockClient(client))
+	root := commandRoot(command)
+
+	err := root.Run(context.Background(), []string{
+		"workflowy", "get", backupItemID[len(backupItemID)-12:],
+		"--method=backup", "--backup-file=" + backupFile,
+		"--read-root-id=" + backupRootID[len(backupRootID)-12:],
+		"--depth=0",
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, client.networkCalls)
+}
+
+func TestGetDoesNotReplaceExplicitNetworkMethodWithBackup(t *testing.T) {
+	backupFile := writeCommandBackup(t)
+	for _, method := range []string{"get", "export"} {
+		t.Run(method, func(t *testing.T) {
+			command := getGetCommandWithClientProvider(withMockClient(nil))
+			root := commandRoot(command)
+
+			err := root.Run(context.Background(), []string{
+				"workflowy", "get", "--method=" + method,
+				"--backup-file=" + backupFile, "--depth=1",
+			})
+
+			require.ErrorContains(t, err, "without using the API")
+		})
+	}
+}
+
+func TestGetRejectsInvalidMethodBeforePreparingRestrictions(t *testing.T) {
+	command := getGetCommandWithClientProvider(withMockClient(nil))
+	root := commandRoot(command)
+
+	err := root.Run(context.Background(), []string{
+		"workflowy", "get", "--method=invalid",
+		"--read-root-id=" + backupRootID,
+	})
+
+	require.EqualError(t, err, `Cannot select access method "invalid": expected "get", "export", or "backup"`)
+}
+
+func TestCountReportBackupResolvesIDsAndRestrictionsWithoutNetwork(t *testing.T) {
+	client := &networkRejectingClient{}
+	provider := &recordingBackupProvider{items: commandBackupItems()}
+	command := getCountReportCommandWithDeps(
+		ReportDeps{BackupProvider: provider, Output: &bytes.Buffer{}},
+		withMockClient(client),
+	)
+	root := commandRoot(command)
+
+	err := root.Run(context.Background(), []string{
+		"workflowy", "count",
+		"--method=backup", "--id=" + backupItemID[len(backupItemID)-12:],
+		"--read-root-id=" + backupRootID[len(backupRootID)-12:], "--threshold=0",
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, client.networkCalls)
+	assert.Equal(t, 1, provider.calls)
+}
+
+func TestReplaceBackupDryRunUsesBackupForValidationWithoutNetwork(t *testing.T) {
+	backupFile := writeCommandBackup(t)
+	client := &networkRejectingClient{}
+	command := getReplaceCommandWithClientProvider(withMockClient(client))
+	root := commandRoot(command)
+
+	err := root.Run(context.Background(), []string{
+		"workflowy", "replace", "Task", "Done",
+		"--method=backup", "--backup-file=" + backupFile, "--dry-run",
+		"--parent-id=" + backupRootID[len(backupRootID)-12:],
+		"--write-root-id=" + backupRootID[len(backupRootID)-12:],
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, client.networkCalls)
+}
+
+func TestTransformBackupDryRunUsesBackupForValidationWithoutNetwork(t *testing.T) {
+	backupFile := writeCommandBackup(t)
+	client := &networkRejectingClient{}
+	command := getTransformCommandWithClientProvider(withMockClient(client))
+	root := commandRoot(command)
+
+	err := root.Run(context.Background(), []string{
+		"workflowy", "transform", backupItemID[len(backupItemID)-12:], "uppercase",
+		"--method=backup", "--backup-file=" + backupFile, "--dry-run", "--depth=0",
+		"--write-root-id=" + backupRootID[len(backupRootID)-12:],
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, client.networkCalls)
+}
+
+func TestBackupMutationCommandsValidateFromBackupBeforeSelectedAPIWrite(t *testing.T) {
+	backupFile := writeCommandBackup(t)
+	tests := []struct {
+		name  string
+		build func(ClientProvider) *cli.Command
+	}{
+		{name: "delete", build: getDeleteCommandWithClientProvider},
+		{name: "complete", build: func(provider ClientProvider) *cli.Command {
+			return getCompletionCommandWithClientProvider("complete", "test", "testing", provider)
+		}},
+		{name: "uncomplete", build: func(provider ClientProvider) *cli.Command {
+			return getCompletionCommandWithClientProvider("uncomplete", "test", "testing", provider)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &networkRejectingClient{}
+			command := test.build(withMockClient(client))
+			root := commandRoot(command)
+
+			err := root.Run(context.Background(), []string{
+				"workflowy", test.name, backupItemID[len(backupItemID)-12:],
+				"--method=backup", "--backup-file=" + backupFile,
+				"--write-root-id=" + backupRootID[len(backupRootID)-12:],
+			})
+
+			require.NoError(t, err)
+			assert.Zero(t, client.networkCalls)
+			assert.Equal(t, 1, client.mutations)
+		})
+	}
+}
+
+func commandRoot(command *cli.Command) *cli.Command {
+	return &cli.Command{
+		Name: "workflowy",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "format", Value: "json"},
+			getReadRootIdFlag(),
+			getWriteRootIdFlag(),
+		},
+		Commands: []*cli.Command{command},
+	}
+}
+
+func writeCommandBackup(t *testing.T) string {
+	t.Helper()
+	filename := filepath.Join(t.TempDir(), "workflowy.backup")
+	data := `[{"id":"` + backupRootID + `","nm":"Project","ch":[{"id":"` + backupItemID + `","nm":"Task"}]}]`
+	require.NoError(t, os.WriteFile(filename, []byte(data), 0o600))
+	return filename
+}
+
+func commandBackupItems() []*workflowy.Item {
+	return []*workflowy.Item{{
+		ID: backupRootID, Name: "Project",
+		Children: []*workflowy.Item{{ID: backupItemID, Name: "Task"}},
+	}}
+}

--- a/cmd/workflowy/client_test.go
+++ b/cmd/workflowy/client_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	genericclient "github.com/mholzen/workflowy/pkg/client"
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+type getCommandClient struct {
+	MockClient
+}
+
+func (client *getCommandClient) ListChildrenRecursiveWithDepth(context.Context, string, int) (*workflowy.ListChildrenResponse, error) {
+	return &workflowy.ListChildrenResponse{Items: []*workflowy.Item{}}, nil
+}
+
+func TestClientProviderSelectsAPI(t *testing.T) {
+	t.Setenv("WORKFLOWY_API_KEY", "test-key")
+
+	tests := []struct {
+		name string
+		args []string
+		want workflowy.APIDeployment
+	}{
+		{name: "production default", args: []string{"test"}, want: workflowy.ProductionAPI},
+		{name: "beta override", args: []string{"test", "--api=beta"}, want: workflowy.BetaAPI},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var selected workflowy.APIDeployment
+			factory := func(deployment workflowy.APIDeployment, _ ...genericclient.Option) (workflowy.Client, error) {
+				selected = deployment
+				return &MockClient{}, nil
+			}
+
+			command := &cli.Command{
+				Flags: []cli.Flag{getAPIFlag(), getAPIKeyFlag()},
+				Action: newClientProvider(factory, false)(func(context.Context, *cli.Command, workflowy.Client) error {
+					return nil
+				}),
+			}
+
+			require.NoError(t, command.Run(context.Background(), test.args))
+			assert.Equal(t, test.want, selected)
+		})
+	}
+}
+
+func TestClientProviderRejectsInvalidAPIBeforeCredentials(t *testing.T) {
+	t.Setenv("WORKFLOWY_API_KEY", "")
+
+	factoryCalls := 0
+	factory := func(workflowy.APIDeployment, ...genericclient.Option) (workflowy.Client, error) {
+		factoryCalls++
+		return &MockClient{}, nil
+	}
+	command := &cli.Command{
+		Flags: []cli.Flag{getAPIFlag(), getAPIKeyFlag()},
+		Action: newClientProvider(factory, true)(func(context.Context, *cli.Command, workflowy.Client) error {
+			return nil
+		}),
+	}
+
+	err := command.Run(context.Background(), []string{
+		"test",
+		"--api=staging",
+		"--api-key-file=" + t.TempDir() + "/missing-api-key",
+	})
+	require.EqualError(t, err, `Cannot select Workflowy API "staging": expected "production" or "beta"`)
+	assert.Zero(t, factoryCalls)
+}
+
+func TestGetCommandUsesSelectedAPI(t *testing.T) {
+	t.Setenv("WORKFLOWY_API_KEY", "test-key")
+
+	var selected workflowy.APIDeployment
+	fakeClient := &getCommandClient{}
+	factory := func(deployment workflowy.APIDeployment, _ ...genericclient.Option) (workflowy.Client, error) {
+		selected = deployment
+		return fakeClient, nil
+	}
+
+	command := getGetCommandWithClientProvider(newClientProvider(factory, false))
+	root := &cli.Command{
+		Name: "workflowy",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "format", Value: "json"},
+			getReadRootIdFlag(),
+			getWriteRootIdFlag(),
+		},
+		Commands: []*cli.Command{command},
+	}
+	err := root.Run(context.Background(), []string{"workflowy", "get", "--api=beta", "--method=get", "--depth=0"})
+
+	require.NoError(t, err)
+	assert.Equal(t, workflowy.BetaAPI, selected)
+}

--- a/cmd/workflowy/client_test.go
+++ b/cmd/workflowy/client_test.go
@@ -19,6 +19,10 @@ func (client *getCommandClient) ListChildrenRecursiveWithDepth(context.Context, 
 	return &workflowy.ListChildrenResponse{Items: []*workflowy.Item{}}, nil
 }
 
+func (client *getCommandClient) ListChildrenRecursiveWithOptions(context.Context, string, workflowy.RecursiveFetchOptions) (*workflowy.RecursiveFetchResult, error) {
+	return &workflowy.RecursiveFetchResult{Response: &workflowy.ListChildrenResponse{Items: []*workflowy.Item{}}}, nil
+}
+
 func TestClientProviderSelectsAPI(t *testing.T) {
 	t.Setenv("WORKFLOWY_API_KEY", "test-key")
 

--- a/cmd/workflowy/commands.go
+++ b/cmd/workflowy/commands.go
@@ -56,12 +56,17 @@ func getGetCommandWithClientProvider(clientProvider ClientProvider) *cli.Command
 				return err
 			}
 
-			readGuard, err := NewReadGuard(ctx, client, getReadRootID(cmd))
+			invocation, err := newCommandInvocation(cmd, client, workflowy.DefaultBackupProvider)
 			if err != nil {
 				return err
 			}
 
-			itemID, err := workflowy.ResolveNodeID(ctx, client, readGuard.DefaultID(params.itemID))
+			readGuard, err := invocation.newReadGuard(ctx, getReadRootID(cmd))
+			if err != nil {
+				return err
+			}
+
+			itemID, err := invocation.resolveNodeID(ctx, readGuard.DefaultID(params.itemID))
 			if err != nil {
 				return fmt.Errorf("cannot resolve ID: %w", err)
 			}
@@ -70,7 +75,7 @@ func getGetCommandWithClientProvider(clientProvider ClientProvider) *cli.Command
 				return err
 			}
 
-			result, err := fetchItems(cmd, ctx, client, itemID, params.depth)
+			result, err := invocation.fetchItems(ctx, cmd, itemID, params.depth)
 			if err != nil {
 				return err
 			}
@@ -94,12 +99,17 @@ func getListCommand() *cli.Command {
 				return err
 			}
 
-			readGuard, err := NewReadGuard(ctx, client, getReadRootID(cmd))
+			invocation, err := newCommandInvocation(cmd, client, workflowy.DefaultBackupProvider)
 			if err != nil {
 				return err
 			}
 
-			itemID, err := workflowy.ResolveNodeID(ctx, client, readGuard.DefaultID(params.itemID))
+			readGuard, err := invocation.newReadGuard(ctx, getReadRootID(cmd))
+			if err != nil {
+				return err
+			}
+
+			itemID, err := invocation.resolveNodeID(ctx, readGuard.DefaultID(params.itemID))
 			if err != nil {
 				return fmt.Errorf("cannot resolve ID: %w", err)
 			}
@@ -108,7 +118,7 @@ func getListCommand() *cli.Command {
 				return err
 			}
 
-			treeResult, err := fetchItems(cmd, ctx, client, itemID, params.depth)
+			treeResult, err := invocation.fetchItems(ctx, cmd, itemID, params.depth)
 			if err != nil {
 				return err
 			}
@@ -435,6 +445,10 @@ func getMoveCommand() *cli.Command {
 }
 
 func getDeleteCommand() *cli.Command {
+	return getDeleteCommandWithClientProvider(withClient)
+}
+
+func getDeleteCommandWithClientProvider(clientProvider ClientProvider) *cli.Command {
 	return &cli.Command{
 		Name:      "delete",
 		Usage:     "Permanently delete a node",
@@ -446,14 +460,18 @@ func getDeleteCommand() *cli.Command {
 			},
 		},
 		Flags: getMethodFlags(),
-		Action: withClient(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
+		Action: clientProvider(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
 			format := cmd.String("format")
 			if err := validateFormat(format); err != nil {
 				return err
 			}
 
-			// Initialize write guard for access control
-			guard, err := NewWriteGuard(ctx, client, getWriteRootID(cmd))
+			invocation, err := newCommandInvocation(cmd, client, workflowy.DefaultBackupProvider)
+			if err != nil {
+				return err
+			}
+
+			guard, err := invocation.newWriteGuard(ctx, getWriteRootID(cmd))
 			if err != nil {
 				return err
 			}
@@ -463,7 +481,7 @@ func getDeleteCommand() *cli.Command {
 				return fmt.Errorf("id is required")
 			}
 
-			itemID, err := workflowy.ResolveNodeID(ctx, client, rawItemID)
+			itemID, err := invocation.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return fmt.Errorf("cannot resolve ID: %w", err)
 			}
@@ -491,11 +509,11 @@ func getDeleteCommand() *cli.Command {
 }
 
 func getCompleteCommand() *cli.Command {
-	return getCompletionCommand("complete", "Mark a node as complete", "completing")
+	return getCompletionCommandWithClientProvider("complete", "Mark a node as complete", "completing", withClient)
 }
 
 func getUncompleteCommand() *cli.Command {
-	return getCompletionCommand("uncomplete", "Mark a node as uncomplete", "uncompleting")
+	return getCompletionCommandWithClientProvider("uncomplete", "Mark a node as uncomplete", "uncompleting", withClient)
 }
 
 func getTargetsCommand() *cli.Command {
@@ -522,7 +540,7 @@ func getTargetsCommand() *cli.Command {
 	}
 }
 
-func getCompletionCommand(commandName, usage, action string) *cli.Command {
+func getCompletionCommandWithClientProvider(commandName, usage, action string, clientProvider ClientProvider) *cli.Command {
 	return &cli.Command{
 		Name:      commandName,
 		Usage:     usage,
@@ -534,14 +552,18 @@ func getCompletionCommand(commandName, usage, action string) *cli.Command {
 			},
 		},
 		Flags: getMethodFlags(),
-		Action: withClient(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
+		Action: clientProvider(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
 			format := cmd.String("format")
 			if err := validateFormat(format); err != nil {
 				return err
 			}
 
-			// Initialize write guard for access control
-			guard, err := NewWriteGuard(ctx, client, getWriteRootID(cmd))
+			invocation, err := newCommandInvocation(cmd, client, workflowy.DefaultBackupProvider)
+			if err != nil {
+				return err
+			}
+
+			guard, err := invocation.newWriteGuard(ctx, getWriteRootID(cmd))
 			if err != nil {
 				return err
 			}
@@ -551,7 +573,7 @@ func getCompletionCommand(commandName, usage, action string) *cli.Command {
 				return fmt.Errorf("id is required")
 			}
 
-			itemID, err := workflowy.ResolveNodeID(ctx, client, rawItemID)
+			itemID, err := invocation.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return fmt.Errorf("cannot resolve ID: %w", err)
 			}
@@ -760,18 +782,23 @@ func getSearchCommand() *cli.Command {
 				return fmt.Errorf("cannot search using the GET method")
 			}
 
-			readGuard, err := NewReadGuard(ctx, client, getReadRootID(cmd))
+			invocation, err := newCommandInvocation(cmd, client, workflowy.DefaultBackupProvider)
 			if err != nil {
 				return err
 			}
 
-			items, err := loadTree(ctx, cmd, client)
+			readGuard, err := invocation.newReadGuard(ctx, getReadRootID(cmd))
+			if err != nil {
+				return err
+			}
+
+			items, err := invocation.loadTree(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
 			rawID := readGuard.DefaultID(getID(cmd))
-			itemID, err := workflowy.ResolveNodeID(ctx, client, rawID)
+			itemID, err := invocation.resolveNodeID(ctx, rawID)
 			if err != nil {
 				return fmt.Errorf("cannot resolve ID: %w", err)
 			}
@@ -851,6 +878,10 @@ func getSearchCommand() *cli.Command {
 }
 
 func getReplaceCommand() *cli.Command {
+	return getReplaceCommandWithClientProvider(withClient)
+}
+
+func getReplaceCommandWithClientProvider(clientProvider ClientProvider) *cli.Command {
 	return &cli.Command{
 		Name:      "replace",
 		Usage:     "Search and replace text in node names using regular expressions",
@@ -894,14 +925,18 @@ Examples:
 			},
 		},
 		Flags: getReplaceFlags(),
-		Action: withClient(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
+		Action: clientProvider(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
 			format := cmd.String("format")
 			if err := validateFormat(format); err != nil {
 				return err
 			}
 
-			// Initialize write guard for access control
-			guard, err := NewWriteGuard(ctx, client, getWriteRootID(cmd))
+			invocation, err := newCommandInvocation(cmd, client, workflowy.DefaultBackupProvider)
+			if err != nil {
+				return err
+			}
+
+			guard, err := invocation.newWriteGuard(ctx, getWriteRootID(cmd))
 			if err != nil {
 				return err
 			}
@@ -922,12 +957,12 @@ Examples:
 				return fmt.Errorf("invalid regular expression: %w", err)
 			}
 
-			items, err := loadTree(ctx, cmd, client)
+			items, err := invocation.loadTree(ctx, cmd)
 			if err != nil {
 				return err
 			}
 
-			parentID, err := workflowy.ResolveNodeID(ctx, client, getParentID(cmd))
+			parentID, err := invocation.resolveNodeID(ctx, getParentID(cmd))
 			if err != nil {
 				return fmt.Errorf("cannot resolve parent ID: %w", err)
 			}

--- a/cmd/workflowy/commands.go
+++ b/cmd/workflowy/commands.go
@@ -1037,6 +1037,12 @@ Examples:
 }
 
 func getMcpCommand() *cli.Command {
+	return getMcpCommandWithRunner(mcp.RunServer)
+}
+
+type mcpRunner func(context.Context, mcp.Config) error
+
+func getMcpCommandWithRunner(runServer mcpRunner) *cli.Command {
 	return &cli.Command{
 		Name:      "mcp",
 		Usage:     "Run as MCP server (stdio transport)",
@@ -1059,6 +1065,7 @@ Examples:
   workflowy mcp --method=backup      # Use local backup file (no API needed)`,
 		Flags: []cli.Flag{
 			getAPIKeyFlag(),
+			getAPIFlag(),
 			&cli.StringFlag{
 				Name:  "expose",
 				Value: "read",
@@ -1077,6 +1084,7 @@ Examples:
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			serverConfig := mcp.Config{
+				API:               cmd.String("api"),
 				APIKeyFile:        cmd.String("api-key-file"),
 				DefaultAPIKeyFile: defaultAPIKeyFile,
 				Expose:            cmd.String("expose"),
@@ -1086,7 +1094,7 @@ Examples:
 				Method:            cmd.String("method"),
 				BackupFile:        cmd.String("backup-file"),
 			}
-			return mcp.RunServer(ctx, serverConfig)
+			return runServer(ctx, serverConfig)
 		},
 	}
 }

--- a/cmd/workflowy/commands.go
+++ b/cmd/workflowy/commands.go
@@ -1133,7 +1133,7 @@ func createClient(apiKeyFile string) (*workflowy.WorkflowyClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return workflowy.NewWorkflowyClient(option), nil
+	return workflowy.NewWorkflowyClient(workflowy.ProductionAPI, option)
 }
 
 type ClientActionFunc func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error

--- a/cmd/workflowy/commands.go
+++ b/cmd/workflowy/commands.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	genericclient "github.com/mholzen/workflowy/pkg/client"
 	"github.com/mholzen/workflowy/pkg/mcp"
 	"github.com/mholzen/workflowy/pkg/mirror"
 	"github.com/mholzen/workflowy/pkg/reports"
@@ -39,13 +40,17 @@ func getCommands() []*cli.Command {
 }
 
 func getGetCommand() *cli.Command {
+	return getGetCommandWithClientProvider(withOptionalClient)
+}
+
+func getGetCommandWithClientProvider(clientProvider ClientProvider) *cli.Command {
 	return &cli.Command{
 		Name:      "get",
 		Usage:     "Get node and descendants",
 		UsageText: "workflowy get [<id>] [options]",
 		Arguments: getFetchArguments(),
 		Flags:     getFetchFlags(),
-		Action: withOptionalClient(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
+		Action: clientProvider(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
 			params, err := getAndValidateFetchParams(cmd)
 			if err != nil {
 				return err
@@ -360,6 +365,7 @@ func getMoveCommand() *cli.Command {
 		},
 		Flags: []cli.Flag{
 			getAPIKeyFlag(),
+			getAPIFlag(),
 			&cli.StringFlag{
 				Name:  "position",
 				Usage: "Position in new parent: top or bottom (default: top)",
@@ -1098,6 +1104,7 @@ func getIDCommand() *cli.Command {
 		},
 		Flags: []cli.Flag{
 			getAPIKeyFlag(),
+			getAPIFlag(),
 		},
 		Action: withClient(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
 			rawID := cmd.StringArg("id")
@@ -1128,35 +1135,46 @@ func getVersionCommand() *cli.Command {
 	}
 }
 
-func createClient(apiKeyFile string) (*workflowy.WorkflowyClient, error) {
-	option, err := workflowy.ResolveAPIKey(apiKeyFile, defaultAPIKeyFile)
-	if err != nil {
-		return nil, err
-	}
-	return workflowy.NewWorkflowyClient(workflowy.ProductionAPI, option)
-}
-
 type ClientActionFunc func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error
 
 type ClientProvider func(ClientActionFunc) cli.ActionFunc
 
-func withClient(fn ClientActionFunc) cli.ActionFunc {
-	return func(ctx context.Context, cmd *cli.Command) error {
-		client, err := createClient(cmd.String("api-key-file"))
-		if err != nil {
-			return err
+type workflowyClientFactory func(workflowy.APIDeployment, ...genericclient.Option) (workflowy.Client, error)
+
+func createWorkflowyClient(deployment workflowy.APIDeployment, options ...genericclient.Option) (workflowy.Client, error) {
+	return workflowy.NewWorkflowyClient(deployment, options...)
+}
+
+func newClientProvider(factory workflowyClientFactory, allowBackupFallback bool) ClientProvider {
+	return func(fn ClientActionFunc) cli.ActionFunc {
+		return func(ctx context.Context, cmd *cli.Command) error {
+			deployment, err := workflowy.ParseAPIDeployment(cmd.String("api"))
+			if err != nil {
+				return err
+			}
+
+			option, err := workflowy.ResolveAPIKey(cmd.String("api-key-file"), defaultAPIKeyFile)
+			if err != nil {
+				if allowBackupFallback {
+					slog.Warn("cannot create API client -- using backup method", "error", err)
+					return fn(ctx, cmd, nil)
+				}
+				return err
+			}
+
+			client, err := factory(deployment, option)
+			if err != nil {
+				return err
+			}
+			return fn(ctx, cmd, client)
 		}
-		return fn(ctx, cmd, client)
 	}
 }
 
+func withClient(fn ClientActionFunc) cli.ActionFunc {
+	return newClientProvider(createWorkflowyClient, false)(fn)
+}
+
 func withOptionalClient(fn ClientActionFunc) cli.ActionFunc {
-	return func(ctx context.Context, cmd *cli.Command) error {
-		client, err := createClient(cmd.String("api-key-file"))
-		if err != nil {
-			slog.Warn("cannot create API client -- using backup method", "error", err)
-			return fn(ctx, cmd, nil)
-		}
-		return fn(ctx, cmd, client)
-	}
+	return newClientProvider(createWorkflowyClient, true)(fn)
 }

--- a/cmd/workflowy/commands.go
+++ b/cmd/workflowy/commands.go
@@ -1062,7 +1062,7 @@ Examples:
   workflowy mcp --expose=read,write  # Explicit groups
   workflowy mcp --expose=get,list    # Specific tools only
   workflowy mcp --method=export      # Force export method for all operations
-  workflowy mcp --method=backup      # Use local backup file (no API needed)`,
+  workflowy mcp --method=backup      # Use local backup for reads and validation`,
 		Flags: []cli.Flag{
 			getAPIKeyFlag(),
 			getAPIFlag(),

--- a/cmd/workflowy/count_report_test.go
+++ b/cmd/workflowy/count_report_test.go
@@ -85,6 +85,14 @@ func (m *MockClient) ListChildrenRecursiveWithDepth(ctx context.Context, itemID 
 	return nil, nil
 }
 
+func (m *MockClient) ListChildrenRecursiveWithOptions(ctx context.Context, itemID string, options workflowy.RecursiveFetchOptions) (*workflowy.RecursiveFetchResult, error) {
+	response, err := m.ListChildrenRecursiveWithDepth(ctx, itemID, options.Depth)
+	if err != nil {
+		return nil, err
+	}
+	return &workflowy.RecursiveFetchResult{Response: response}, nil
+}
+
 func (m *MockClient) UpdateNode(ctx context.Context, itemID string, req *workflowy.UpdateNodeRequest) (*workflowy.UpdateNodeResponse, error) {
 	return nil, nil
 }

--- a/cmd/workflowy/fetch.go
+++ b/cmd/workflowy/fetch.go
@@ -187,14 +187,17 @@ func fetchFromBackup(backupFile string, itemID string, depth int, ancestorOpts a
 	if err != nil {
 		return nil, err
 	}
+	return fetchFromTree(items, itemID, depth, ancestorOpts)
+}
 
+func fetchFromTree(items []*workflowy.Item, itemID string, depth int, ancestorOpts ancestorOptions) (interface{}, error) {
 	if itemID != "None" {
 		if ancestorOpts.enabled {
 			found, ancestors := workflowy.FindItemWithAncestors(items, itemID)
 			if found == nil {
 				return nil, fmt.Errorf("item %s not found in backup", itemID)
 			}
-			ancestors, err = applyAncestorOptions(ancestors, ancestorOpts)
+			ancestors, err := applyAncestorOptions(ancestors, ancestorOpts)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/workflowy/flags.go
+++ b/cmd/workflowy/flags.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mholzen/workflowy/pkg/workflowy"
 	"github.com/urfave/cli/v3"
 )
 
@@ -22,6 +23,7 @@ func getMethodFlags() []cli.Flag {
 			Usage: "Access method: get, export or backup\n\tDefaults to 'get' for depth 1-3, 'export' for depth 4+, 'backup' if no api key provided",
 		},
 		getAPIKeyFlag(),
+		getAPIFlag(),
 		&cli.StringFlag{
 			Name:  "backup-file",
 			Usage: "Path to backup file (default: latest in ~/Dropbox/Apps/Workflowy/Data)",
@@ -65,6 +67,7 @@ func getFetchFlags() []cli.Flag {
 func getWriteFlags(commandFlags ...cli.Flag) []cli.Flag {
 	flags := []cli.Flag{
 		getAPIKeyFlag(),
+		getAPIFlag(),
 		&cli.StringFlag{
 			Name:  "name",
 			Usage: "Update node name/title",
@@ -133,6 +136,7 @@ func getMirrorReportFlags() []cli.Flag {
 			Usage: "Path to backup file (default: latest in ~/Dropbox/Apps/Workflowy/Data)",
 		},
 		getAPIKeyFlag(),
+		getAPIFlag(),
 	}
 	flags = append(flags, getIdFlag("ID to start from (default: root)"))
 	flags = append(flags, getReportOutputFlags()...)
@@ -279,6 +283,14 @@ func getAPIKeyFlag() *cli.StringFlag {
 	}
 }
 
+func getAPIFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:  "api",
+		Value: string(workflowy.ProductionAPI),
+		Usage: "Workflowy API deployment: production or beta",
+	}
+}
+
 func getParentID(cmd *cli.Command) string {
 	return cmd.String("parent-id")
 }
@@ -310,4 +322,3 @@ func getReadRootIdFlag() cli.Flag {
 func getReadRootID(cmd *cli.Command) string {
 	return cmd.String("read-root-id")
 }
-

--- a/cmd/workflowy/flags_test.go
+++ b/cmd/workflowy/flags_test.go
@@ -6,9 +6,73 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mholzen/workflowy/pkg/workflowy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 )
+
+func TestCommandsExposeAPIFlag(t *testing.T) {
+	commands := make(map[string]*cli.Command)
+	for _, command := range getCommands() {
+		commands[command.Name] = command
+		for _, subcommand := range command.Commands {
+			commands[command.Name+" "+subcommand.Name] = subcommand
+		}
+	}
+
+	requiredPaths := []string{
+		"get",
+		"list",
+		"create",
+		"update",
+		"move",
+		"delete",
+		"complete",
+		"uncomplete",
+		"targets",
+		"search",
+		"replace",
+		"transform",
+		"id",
+		"report count",
+		"report children",
+		"report created",
+		"report modified",
+		"report mirrors",
+	}
+
+	for _, path := range requiredPaths {
+		t.Run(path, func(t *testing.T) {
+			command := commands[path]
+			require.NotNil(t, command)
+
+			apiFlag := findStringFlag(command.Flags, "api")
+			require.NotNil(t, apiFlag, "%s must expose --api", path)
+			assert.Equal(t, string(workflowy.ProductionAPI), apiFlag.Value)
+		})
+	}
+}
+
+func TestCommandsWithoutAPIFlag(t *testing.T) {
+	commands := make(map[string]*cli.Command)
+	for _, command := range getCommands() {
+		commands[command.Name] = command
+	}
+
+	assert.Nil(t, findStringFlag(commands["mcp"].Flags, "api"), "mcp is added atomically with MCP config")
+	assert.Nil(t, findStringFlag(commands["version"].Flags, "api"))
+}
+
+func findStringFlag(flags []cli.Flag, name string) *cli.StringFlag {
+	for _, flag := range flags {
+		stringFlag, ok := flag.(*cli.StringFlag)
+		if ok && stringFlag.Name == name {
+			return stringFlag
+		}
+	}
+	return nil
+}
 
 func TestGetWriteFlags_IncludesAPIKeyFile(t *testing.T) {
 	flags := getWriteFlags()

--- a/cmd/workflowy/flags_test.go
+++ b/cmd/workflowy/flags_test.go
@@ -35,6 +35,7 @@ func TestCommandsExposeAPIFlag(t *testing.T) {
 		"replace",
 		"transform",
 		"id",
+		"mcp",
 		"report count",
 		"report children",
 		"report created",
@@ -60,7 +61,6 @@ func TestCommandsWithoutAPIFlag(t *testing.T) {
 		commands[command.Name] = command
 	}
 
-	assert.Nil(t, findStringFlag(commands["mcp"].Flags, "api"), "mcp is added atomically with MCP config")
 	assert.Nil(t, findStringFlag(commands["version"].Flags, "api"))
 }
 

--- a/cmd/workflowy/invocation.go
+++ b/cmd/workflowy/invocation.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/urfave/cli/v3"
+)
+
+type commandInvocation struct {
+	client         workflowy.Client
+	backupProvider workflowy.BackupProvider
+	backupItems    []*workflowy.Item
+	backup         bool
+}
+
+func newCommandInvocation(
+	cmd *cli.Command,
+	client workflowy.Client,
+	backupProvider workflowy.BackupProvider,
+) (*commandInvocation, error) {
+	invocation := &commandInvocation{client: client, backupProvider: backupProvider}
+	method := cmd.String("method")
+	if method != "" && method != "get" && method != "export" && method != "backup" {
+		return nil, fmt.Errorf("Cannot select access method %q: expected \"get\", \"export\", or \"backup\"", method)
+	}
+	if client == nil && (method == "get" || method == "export") {
+		return nil, fmt.Errorf("Cannot use method %q without using the API", method)
+	}
+	if method != "backup" && !(method == "" && client == nil) {
+		return invocation, nil
+	}
+
+	items, err := loadFromBackupProvider(cmd.String("backup-file"), backupProvider)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot prepare backup invocation: %w", err)
+	}
+	invocation.backupItems = items
+	invocation.backup = true
+	return invocation, nil
+}
+
+func (invocation *commandInvocation) usesBackup() bool {
+	return invocation.backup
+}
+
+func (invocation *commandInvocation) resolveNodeID(ctx context.Context, rawID string) (string, error) {
+	if invocation.usesBackup() {
+		return workflowy.ResolveNodeIDFromTree(invocation.backupItems, rawID)
+	}
+	return workflowy.ResolveNodeID(ctx, invocation.client, rawID)
+}
+
+func (invocation *commandInvocation) newReadGuard(ctx context.Context, readRootID string) (*ReadGuard, error) {
+	if invocation.usesBackup() {
+		return newReadGuardFromTree(invocation.backupItems, readRootID)
+	}
+	return NewReadGuard(ctx, invocation.client, readRootID)
+}
+
+func (invocation *commandInvocation) newWriteGuard(ctx context.Context, writeRootID string) (*WriteGuard, error) {
+	if invocation.usesBackup() {
+		return newWriteGuardFromTree(invocation.backupItems, writeRootID)
+	}
+	return NewWriteGuard(ctx, invocation.client, writeRootID)
+}
+
+func (invocation *commandInvocation) loadTree(ctx context.Context, cmd *cli.Command) ([]*workflowy.Item, error) {
+	if invocation.usesBackup() {
+		return invocation.backupItems, nil
+	}
+	return loadTreeWithBackupProvider(ctx, cmd, invocation.client, invocation.backupProvider)
+}
+
+func (invocation *commandInvocation) fetchItems(
+	ctx context.Context,
+	cmd *cli.Command,
+	itemID string,
+	depth int,
+) (interface{}, error) {
+	if !invocation.usesBackup() {
+		return fetchItems(cmd, ctx, invocation.client, itemID, depth)
+	}
+
+	ancestorOptions, err := resolveAncestorOptions(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return fetchFromTree(invocation.backupItems, itemID, depth, ancestorOptions)
+}

--- a/cmd/workflowy/mcp_api_test.go
+++ b/cmd/workflowy/mcp_api_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mholzen/workflowy/pkg/mcp"
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPCommandPassesAPISelection(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "production default", args: []string{"mcp"}, want: string(workflowy.ProductionAPI)},
+		{name: "beta override", args: []string{"mcp", "--api=beta"}, want: string(workflowy.BetaAPI)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var config mcp.Config
+			command := getMcpCommandWithRunner(func(_ context.Context, received mcp.Config) error {
+				config = received
+				return nil
+			})
+
+			require.NoError(t, command.Run(context.Background(), test.args))
+			assert.Equal(t, test.want, config.API)
+		})
+	}
+}

--- a/cmd/workflowy/read_guard.go
+++ b/cmd/workflowy/read_guard.go
@@ -46,6 +46,20 @@ func NewReadGuard(ctx context.Context, client workflowy.Client, readRootID strin
 	return guard, nil
 }
 
+func newReadGuardFromTree(items []*workflowy.Item, readRootID string) (*ReadGuard, error) {
+	guard := &ReadGuard{readRootID: readRootID, tree: items}
+	if !workflowy.IsRestricted(readRootID) {
+		return guard, nil
+	}
+
+	resolvedID, err := workflowy.ResolveNodeIDFromTree(items, readRootID)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot resolve read-root-id %q from backup: %w", readRootID, err)
+	}
+	guard.readRootID = resolvedID
+	return guard, nil
+}
+
 // IsRestricted returns true if read restrictions are in effect.
 func (g *ReadGuard) IsRestricted() bool {
 	return workflowy.IsRestricted(g.readRootID)

--- a/cmd/workflowy/report_api_test.go
+++ b/cmd/workflowy/report_api_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	genericclient "github.com/mholzen/workflowy/pkg/client"
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingBackupProvider struct {
+	filename string
+	items    []*workflowy.Item
+}
+
+func (provider *recordingBackupProvider) ReadBackupFile(filename string) ([]*workflowy.Item, error) {
+	provider.filename = filename
+	return provider.items, nil
+}
+
+func (provider *recordingBackupProvider) ReadLatestBackup() ([]*workflowy.Item, error) {
+	return provider.items, nil
+}
+
+func TestCountReportBackupUploadUsesSelectedAPI(t *testing.T) {
+	t.Setenv("WORKFLOWY_API_KEY", "test-key")
+
+	backupProvider := &recordingBackupProvider{items: []*workflowy.Item{
+		{
+			ID:   "00000000-0000-0000-0000-000000000001",
+			Name: "Project",
+			Children: []*workflowy.Item{
+				{ID: "00000000-0000-0000-0000-000000000002", Name: "Task"},
+			},
+		},
+	}}
+	betaClient := &MockClient{}
+	var selected workflowy.APIDeployment
+	factory := func(deployment workflowy.APIDeployment, _ ...genericclient.Option) (workflowy.Client, error) {
+		selected = deployment
+		return betaClient, nil
+	}
+
+	command := getCountReportCommandWithDeps(
+		ReportDeps{BackupProvider: backupProvider, Output: &bytes.Buffer{}},
+		newClientProvider(factory, true),
+	)
+	err := command.Run(context.Background(), []string{
+		"count",
+		"--api=beta",
+		"--method=backup",
+		"--backup-file=fixture.json",
+		"--upload",
+		"--threshold=0",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "fixture.json", backupProvider.filename)
+	assert.Equal(t, workflowy.BetaAPI, selected)
+	assert.NotEmpty(t, betaClient.CreatedNodes)
+}

--- a/cmd/workflowy/report_api_test.go
+++ b/cmd/workflowy/report_api_test.go
@@ -14,14 +14,17 @@ import (
 type recordingBackupProvider struct {
 	filename string
 	items    []*workflowy.Item
+	calls    int
 }
 
 func (provider *recordingBackupProvider) ReadBackupFile(filename string) ([]*workflowy.Item, error) {
+	provider.calls++
 	provider.filename = filename
 	return provider.items, nil
 }
 
 func (provider *recordingBackupProvider) ReadLatestBackup() ([]*workflowy.Item, error) {
+	provider.calls++
 	return provider.items, nil
 }
 
@@ -59,6 +62,7 @@ func TestCountReportBackupUploadUsesSelectedAPI(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "fixture.json", backupProvider.filename)
+	assert.Equal(t, 1, backupProvider.calls)
 	assert.Equal(t, workflowy.BetaAPI, selected)
 	assert.NotEmpty(t, betaClient.CreatedNodes)
 }

--- a/cmd/workflowy/reports.go
+++ b/cmd/workflowy/reports.go
@@ -135,18 +135,23 @@ func loadAndCountDescendants(ctx context.Context, cmd *cli.Command, client workf
 }
 
 func loadAndCountDescendantsWithBackupProvider(ctx context.Context, cmd *cli.Command, client workflowy.Client, backupProvider workflowy.BackupProvider) (workflowy.Descendants, error) {
-	readGuard, err := NewReadGuard(ctx, client, getReadRootID(cmd))
+	invocation, err := newCommandInvocation(cmd, client, backupProvider)
 	if err != nil {
 		return nil, err
 	}
 
-	items, err := loadTreeWithBackupProvider(ctx, cmd, client, backupProvider)
+	readGuard, err := invocation.newReadGuard(ctx, getReadRootID(cmd))
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := invocation.loadTree(ctx, cmd)
 	if err != nil {
 		return nil, err
 	}
 
 	rawID := readGuard.DefaultID(getID(cmd))
-	itemID, err := workflowy.ResolveNodeID(ctx, client, rawID)
+	itemID, err := invocation.resolveNodeID(ctx, rawID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve item ID: %w", err)
 	}
@@ -233,18 +238,23 @@ func DefaultReportDeps() ReportDeps {
 
 func countReportAction(deps ReportDeps) func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
 	return func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
-		readGuard, err := NewReadGuard(ctx, client, getReadRootID(cmd))
+		invocation, err := newCommandInvocation(cmd, client, deps.BackupProvider)
 		if err != nil {
 			return err
 		}
 
-		items, err := loadTreeWithBackupProvider(ctx, cmd, client, deps.BackupProvider)
+		readGuard, err := invocation.newReadGuard(ctx, getReadRootID(cmd))
+		if err != nil {
+			return err
+		}
+
+		items, err := invocation.loadTree(ctx, cmd)
 		if err != nil {
 			return err
 		}
 
 		rawID := readGuard.DefaultID(getID(cmd))
-		itemID, err := workflowy.ResolveNodeID(ctx, client, rawID)
+		itemID, err := invocation.resolveNodeID(ctx, rawID)
 		if err != nil {
 			return fmt.Errorf("cannot resolve item ID: %w", err)
 		}

--- a/cmd/workflowy/transform.go
+++ b/cmd/workflowy/transform.go
@@ -14,6 +14,10 @@ import (
 )
 
 func getTransformCommand() *cli.Command {
+	return getTransformCommandWithClientProvider(withClient)
+}
+
+func getTransformCommandWithClientProvider(clientProvider ClientProvider) *cli.Command {
 	return &cli.Command{
 		Name:      "transform",
 		Usage:     "Transform node names and/or notes using built-in or shell transformations",
@@ -50,7 +54,7 @@ Examples:
 			},
 		},
 		Flags: getTransformFlags(),
-		Action: withClient(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
+		Action: clientProvider(func(ctx context.Context, cmd *cli.Command, client workflowy.Client) error {
 			return runTransform(ctx, cmd, client)
 		}),
 	}
@@ -132,7 +136,12 @@ func runTransform(ctx context.Context, cmd *cli.Command, client workflowy.Client
 		return fmt.Errorf("id is required")
 	}
 
-	itemID, err := workflowy.ResolveNodeID(ctx, client, rawItemID)
+	invocation, err := newCommandInvocation(cmd, client, workflowy.DefaultBackupProvider)
+	if err != nil {
+		return err
+	}
+
+	itemID, err := invocation.resolveNodeID(ctx, rawItemID)
 	if err != nil {
 		return fmt.Errorf("cannot resolve ID: %w", err)
 	}
@@ -140,7 +149,7 @@ func runTransform(ctx context.Context, cmd *cli.Command, client workflowy.Client
 	// Validate write-root scope only if restriction is in effect
 	writeRootID := getWriteRootID(cmd)
 	if workflowy.IsWriteRestricted(writeRootID) {
-		guard, err := NewWriteGuard(ctx, client, writeRootID)
+		guard, err := invocation.newWriteGuard(ctx, writeRootID)
 		if err != nil {
 			return err
 		}
@@ -156,7 +165,7 @@ func runTransform(ctx context.Context, cmd *cli.Command, client workflowy.Client
 	}
 
 	// Use the same fetch logic as get command
-	result, err := fetchItems(cmd, ctx, client, itemID, depth)
+	result, err := invocation.fetchItems(ctx, cmd, itemID, depth)
 	if err != nil {
 		return err
 	}

--- a/cmd/workflowy/write_guard.go
+++ b/cmd/workflowy/write_guard.go
@@ -49,6 +49,20 @@ func NewWriteGuard(ctx context.Context, client workflowy.Client, writeRootID str
 	return guard, nil
 }
 
+func newWriteGuardFromTree(items []*workflowy.Item, writeRootID string) (*WriteGuard, error) {
+	guard := &WriteGuard{writeRootID: writeRootID, tree: items}
+	if !workflowy.IsWriteRestricted(writeRootID) {
+		return guard, nil
+	}
+
+	resolvedID, err := workflowy.ResolveNodeIDFromTree(items, writeRootID)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot resolve write-root-id %q from backup: %w", writeRootID, err)
+	}
+	guard.writeRootID = resolvedID
+	return guard, nil
+}
+
 // IsRestricted returns true if write restrictions are in effect.
 func (g *WriteGuard) IsRestricted() bool {
 	return workflowy.IsWriteRestricted(g.writeRootID)

--- a/docs/2026-08-04-mirror-support-design.md
+++ b/docs/2026-08-04-mirror-support-design.md
@@ -1,0 +1,398 @@
+# Workflowy Mirror Support Design
+
+## Summary
+
+Add consistent mirror-aware descendant fetching across Workflowy's `get`, `export`, and `backup` access methods; make search traverse mirror contents with explicit occurrence controls; and add CLI and MCP commands for creating mirrors. Mirror behavior is enabled by default, can be disabled per invocation, and depends on mirror metadata rather than a hardcoded production/beta capability check.
+
+This design uses the source-tree and resolved-tree language defined in `docs/architecture.md`. Detailed contract research is recorded in `docs/research/2026-08-03-workflowy-mirror-children.md`.
+
+## Motivation
+
+Workflowy's beta list endpoint returns an origin node's children when the requested parent is a mirror. The beta export remains a flat source tree: mirror rows expose `data.mirror.origin_id`, but the origin's child rows retain the origin's `parent_id`. Backups carry the equivalent relationship as `metadata.mirror.originalId` and likewise usually omit children beneath mirror rows.
+
+Without local resolution, `method=export` and `method=backup` show mirror nodes as empty or incomplete even though `method=get` exposes their descendants. Users should receive the same descendant behavior from all access methods, while retaining a way to treat mirrors as leaves.
+
+Search should see content reachable through mirrors without returning the same underlying match repeatedly by default. Reports and transforms should retain source-tree semantics so mirrors do not inflate counts or cause repeated writes.
+
+Workflowy's beta API also supports creating mirrors. The CLI and MCP server should expose that operation through the existing deployment-selection and access-control conventions without preventing requests to production.
+
+## Goals
+
+- Return mirror descendants consistently from `get`, `export`, and `backup` reads.
+- Enable mirror resolution by default and allow callers to make mirrors leaves.
+- Search content reached through mirrors once by default or once per occurrence on request.
+- Keep reports, transforms, and write validation on source trees.
+- Create mirrors through matching CLI and MCP interfaces.
+- Let the selected API deployment determine whether the mirror endpoint is supported.
+- Preserve troubleshooting paths through contextual warnings, errors, and tests.
+
+## Non-Goals
+
+- Do not add a separate mirror-removal command; existing node deletion removes a mirror.
+- Do not make reports count resolved mirror descendants.
+- Do not make transforms apply the same write through multiple mirror occurrences.
+- Do not normalize all beta and production response differences.
+- Do not maintain a deployment capability table or preflight endpoint support.
+- Do not merge a mirror node's source children with its origin's children.
+
+## Domain Model
+
+### Source tree
+
+A source tree contains the parent-child relationships encoded directly by an export or backup. It remains the input for write validation, reports, transforms, and mirror analysis. Mirror-aware fetch and search read validation uses the resolved tree.
+
+### Resolved tree
+
+A resolved tree is an immutable view derived from a source tree. It is not a second, fully materialized tree. Fetch and search traverse the source tree through the resolved child rule only as their operation requires:
+
+| Node state | `resolve_mirrors=true` | `resolve_mirrors=false` |
+| --- | --- | --- |
+| Ordinary node | Source children | Source children |
+| Mirror with available origin | Origin's source children | No children |
+| Mirror with null origin | Mirror's source children | No children |
+| Mirror with referenced origin absent from source tree | Mirror's source children and warning | No children |
+
+For a resolved mirror, origin children replace mirror source children; the two sets are never combined. Nested mirrors follow the same rule recursively.
+
+### Mirror reference
+
+One Workflowy module owns mirror detection and source-field normalization. It recognizes:
+
+- API/export: `Item.Data["mirror"]["origin_id"]`
+- Backup: `Item.Data["mirror"]["originalId"]`
+
+The result distinguishes an ordinary node, a mirror with an origin ID, a mirror with a null origin, and malformed mirror metadata. This distinction is required because `origin_id: null` still identifies a mirror and must become a leaf when resolution is disabled.
+
+Workflowy origin nodes legitimately carry `mirror_ids` or `mirrorRootIds` without an origin field. A mirror object with neither `origin_id` nor `originalId` is therefore ordinary for child resolution. Malformed metadata means one of the recognized origin fields is present but its value is neither a string nor null. It still identifies a mirror. With resolution enabled, traversal uses the mirror's source children and emits a contextual warning; with resolution disabled, the mirror is a leaf. A non-object value under the `mirror` key has no recognized origin field and remains ordinary for child resolution.
+
+Mirror detection is based only on item metadata. It never checks `APIDeployment`, so production begins using the same behavior when its responses expose supported metadata.
+
+### Node occurrence
+
+A node occurrence is one path to a node in a resolved tree. Origin descendants can have an original occurrence and multiple occurrences beneath mirrors. Occurrences share node IDs but carry different ancestor paths.
+
+An occurrence's identity is the ordered ancestor-ID path plus its node ID. This identity is used wherever separate occurrences must survive, including `search_mirrors=true` tree output. Node IDs and origin IDs remain data attributes and default-deduplication keys; they are not occurrence identities.
+
+For search deduplication, a mirror node uses its origin node ID as the equality key when the origin ID is available; an ordinary node uses its own ID. This prevents multiple mirror roots for the same origin from producing repeated default results. The returned result still uses the ID and path of the chosen occurrence.
+
+## ResolvedTree Module
+
+Create a focused Workflowy module named `ResolvedTree`. It accepts source-tree roots, builds a private ID index once, and exposes two behaviors:
+
+1. Locate a requested occurrence and return fresh, depth-limited resolved roots or a resolved subtree for fetch operations.
+2. Visit node occurrences with their ancestor paths for search without retaining non-matching occurrences.
+
+The module does not mutate source `Item` values or their `Children` slices. Fetch results contain fresh item structures so depth limiting, flattening, filtering, and formatting cannot alter the source tree or another occurrence. A targeted fetch does not enumerate unrelated roots. A finite-depth root fetch does not traverse below that depth. Search streams every occurrence path to its matcher and discards non-matching occurrences immediately. The matcher retains one selected match per equality key by default, replacing a mirrored match with a later original occurrence when available; `search_mirrors=true` retains every matching occurrence instead.
+
+Mirror expansion tracks the source node IDs currently being expanded on the current path, including ordinary nodes and the initially requested source subtree. Before following a mirror origin, it checks that origin ID against this expansion path. If the origin is already present, the affected mirror occurrence becomes a leaf and a warning identifies the mirror, origin, and path. This stops an origin containing a mirror of itself before its subtree is expanded a second time. The expansion path is local to each traversal branch, not global, because the same origin may validly appear at multiple independent mirror locations. Recursive direct API fetching applies the same rule using node IDs and mirror metadata returned by the API.
+
+Path-local cycle detection bounds each branch but does not bound the number of distinct branches. Layered or densely connected mirrors can produce exponentially many non-cyclic paths. Search must visit those paths because completion state and cycle boundaries depend on occurrence ancestry, but it retains only active traversal state and selected matches rather than a complete occurrence tree. Unlimited root output can remain large because the complete output was explicitly requested, and `search_mirrors=true` can retain many matches; diagnostics make traversal and retention growth visible.
+
+When a non-empty origin ID is absent from the source-tree index, the module uses the mirror's source children and logs the mirror ID, missing origin ID, and source label. A documented null origin uses source children without failing the invocation. When resolution is disabled, all recognized mirrors are leaves and no origin lookup occurs.
+
+## User Interface
+
+### Mirror resolution
+
+The CLI `get`, `list`, and `search` commands accept a command-local boolean option:
+
+```text
+--resolve-mirrors=<true|false>
+    Resolve mirror descendants (default: true)
+```
+
+The matching MCP tools `workflowy_get`, `workflowy_list`, and `workflowy_search` accept:
+
+```json
+{
+  "resolve_mirrors": false
+}
+```
+
+The MCP property is boolean and defaults to `true`. The option controls descendants only. A requested mirror node is still returned with the content and metadata supplied by the selected source.
+
+The option applies to every access method:
+
+- `get`: inspect each retrieved node's mirror metadata before requesting its children. When resolution is disabled, a mirror is returned without descendants.
+- `export`: derive the requested result from `ResolvedTree`.
+- `backup`: derive the requested result from `ResolvedTree`.
+
+For recursive `get`, ordinary children are fetched normally. A child identified as a mirror is not used as the parent of another list request when resolution is disabled. When resolution is enabled, Workflowy's server-provided child behavior remains authoritative.
+
+### Search mirror occurrences
+
+The CLI `search` command accepts:
+
+```text
+--search-mirrors
+    Return matches from each mirror occurrence
+```
+
+The MCP `workflowy_search` tool accepts boolean `search_mirrors`, defaulting to `false`.
+
+Search always uses the resolved tree when `resolve_mirrors=true`:
+
+- Default: return one result per equality key. Prefer an original occurrence when it is inside the search scope. Otherwise retain the first mirror occurrence in source-tree priority order.
+- `search_mirrors=true`: return every matching occurrence, including the original occurrence when it is inside the search scope. Each result retains that occurrence's parent and path.
+
+`resolve_mirrors=false` with `search_mirrors=true` is invalid and returns:
+
+```text
+Cannot search mirror occurrences when mirror resolution is disabled
+```
+
+All existing flat, grouped, and tree search output modes use the same occurrence policy before grouping and sorting.
+
+Tree output keys its internal branches by occurrence identity rather than node ID. Therefore `search_mirrors=true` can retain two branches containing the same node IDs beneath different mirror paths. The serialized nodes continue to expose Workflowy node IDs; the occurrence identity is traversal state, not a new public identifier.
+
+### Mirror creation command
+
+Add a CLI command:
+
+```text
+workflowy mirror <id> <parent-id> [--position=top|bottom] [--method=get|export|backup] [--api=production|beta]
+```
+
+`api` is the existing shared deployment selector, not a mirror-specific requirement. The command does not enforce beta. It resolves and validates through the selected deployment, sends the mirror request there, and wraps whatever API error that deployment returns. `method` chooses the read source used to resolve IDs and enforce access restrictions; the write always uses the selected API deployment.
+
+The command accepts the repository's normal full UUID, unique short ID, and Workflowy URL inputs for `id` and `parent-id`. Target keys may be resolved to full UUIDs when the selected validation source supports them. Root (`None`) is rejected as a destination. The request sent to Workflowy always contains full IDs.
+
+`position` accepts `top` and `bottom`; omission uses Workflowy's default. Successful text output identifies both the new mirror ID and the origin ID. JSON output returns the response object unchanged.
+
+Add an MCP tool:
+
+```text
+workflowy_mirror
+```
+
+with parameters:
+
+| Parameter | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `id` | string | yes | Node to mirror |
+| `parent_id` | string | yes | Destination parent |
+| `position` | string enum | no | `top` or `bottom` |
+| `method` | string enum | no | Validation source: `get`, `export`, or `backup` |
+| `api` | string enum | no | Selected Workflowy deployment |
+
+The tool joins the MCP `write` and `all` groups and receives the same centralized per-invocation API selection wrapper as other network tools. The `mirror` expose alias maps to it.
+
+Existing `workflowy delete <mirror-id>` and `workflowy_delete` remain the supported removal interfaces because Workflowy's ordinary delete endpoint has the same effect as its mirror-specific delete endpoint.
+
+## Workflowy Client Interface
+
+Add request and response types that reflect the operation rather than reusing move types:
+
+```go
+type MirrorNodeRequest struct {
+    ParentID string  `json:"parent_id"`
+    Position *string `json:"position,omitempty"`
+}
+
+type MirrorNodeResponse struct {
+    ItemID   string `json:"item_id"`
+    OriginID string `json:"origin_id"`
+}
+```
+
+`MirrorNodeRequest.SetPosition` uses the same position validation as create and move. Extend `workflowy.Client` with:
+
+```go
+MirrorNode(ctx context.Context, itemID string, request *MirrorNodeRequest) (*MirrorNodeResponse, error)
+```
+
+The concrete client sends `POST /nodes/:id/mirror`. It does not branch on deployment or interpret unsupported-endpoint responses.
+
+Recursive child fetching receives an explicit mirror-resolution choice. It returns mirror nodes unchanged and skips their descendant request when resolution is disabled. It tracks every source node ID on each active expansion path, beginning with the initially requested ordinary or mirror node, so recursive requests stop safely at mirror cycles. Authentication and HTTP debug logging remain unchanged.
+
+## Access Restrictions
+
+Resolved fetch and search operations evaluate read restrictions against the same resolved tree used for their results. A mirror under the read root therefore makes its resolved descendants readable through that occurrence. An ID-only access check passes when at least one occurrence with the target ID is reachable below the resolved read root.
+
+When a requested ID has multiple reachable occurrences, fetch selects the original occurrence if it is inside the resolved read scope; otherwise it selects the first reachable occurrence in source-tree priority order. The same rule chooses an ancestor path when ancestor output is requested. A fetch that does not expose ancestors still returns the chosen occurrence's fresh node structure and resolved descendants. Reports, transforms, and write operations retain source-tree validation.
+
+Mirror creation validates:
+
+1. The requested source node against `read_root_id`.
+2. The effective destination against `write_root_id`.
+
+Workflowy resolves a mirror destination parent to that parent's origin before creating the new mirror. When a write restriction is active and the validation source identifies the requested parent as a mirror with an available origin, validation uses that origin ID. This prevents a parent mirror inside the write root from redirecting the actual write outside the permitted source-tree scope.
+
+If the validation source identifies a mirror parent but cannot provide its origin, restricted mirror creation fails contextually rather than guessing the effective destination. With no write restriction, the selected API remains responsible for destination resolution and validation.
+
+The API also rejects a destination that resolves to the same origin being mirrored. The client does not duplicate this server rule unless the already-loaded validation data proves the conflict; the API's actual response remains authoritative.
+
+## Data Flow
+
+### Export or backup fetch
+
+1. Load the source tree once from the selected method.
+2. Resolve the requested ID and active read root against that source.
+3. Construct `ResolvedTree` with the source label.
+4. If an original occurrence is directly reachable inside the resolved read scope, select it without walking unrelated branches. Reachability must validate every ancestor edge with the resolved child rule because available mirror origins replace their mirror's source children. Otherwise traverse until the first reachable mirror occurrence is found.
+5. Materialize only that occurrence and its requested descendant depth, carrying its ancestor expansion-path state so cycle decisions match the path through which access was granted.
+6. Format or flatten only the fresh resolved result.
+
+For a root request, materialize each resolved scope root directly at the requested depth. Do not perform a separate unlimited selection traversal first.
+
+### Direct API fetch
+
+1. Retrieve the requested node when the request is not for the root.
+2. Return immediately without children when depth is zero.
+3. If resolution is disabled and the node is a mirror, return it as a leaf.
+4. Otherwise fetch children and recurse.
+5. Before recursing into each returned child, apply the same metadata-driven mirror check.
+
+### Search
+
+1. Load the export or backup source tree once.
+2. Construct `ResolvedTree` and select the requested search-root occurrence using the same original-first, first-reachable-mirror fallback as fetch. Carry the selected occurrence's ancestor and expansion path into its subtree traversal.
+3. Visit occurrences one at a time and evaluate the search pattern immediately.
+4. Visit every occurrence path because completion filtering and mirror-cycle boundaries depend on its ancestry. Discard non-matches immediately. Deduplicate retained matches by origin ID for mirrors and node ID otherwise unless `search_mirrors=true`.
+5. Prefer an original in-scope occurrence; otherwise retain the first mirror occurrence by source-tree priority.
+6. Group, sort, and render the selected occurrences with their chosen paths.
+
+### Mirror creation
+
+1. Select the deployment through the existing CLI or MCP API-selection path.
+2. Resolve source and parent references to full IDs using the selected validation source.
+3. Validate source read access.
+4. Determine and validate the effective destination when write restrictions apply.
+5. Validate position.
+6. Send `POST /nodes/:id/mirror` to the selected deployment.
+7. Return `item_id` and `origin_id`, or wrap the deployment's actual error with source, parent, and deployment context.
+
+## Error Handling and Observability
+
+New errors follow the repository's `Cannot ...` convention and contain the relevant IDs, source, and deployment. Required cases include:
+
+- Conflicting search flags.
+- Restricted mirror creation with an unresolved effective destination.
+- Source or destination not found in the selected validation source.
+- Invalid root destination or position.
+- API errors from mirror creation, preserving the actual status and body.
+
+Warnings are emitted when:
+
+- A non-empty origin reference is absent from the source tree and source children are used.
+- Malformed mirror metadata falls back to source children.
+- A mirror cycle stops expansion.
+
+Warning attributes include the mirror ID, origin ID when available, source label, and operation. Missing-origin and malformed-metadata warnings remain contextual per encounter. Repeated cycles are consolidated by mirror/origin pair per traversal; the warning includes the first path and total `occurrences`, while the summary's cycle count includes every encounter. No warning is emitted merely because a deployment or ordinary node lacks mirror metadata.
+
+Each resolved-tree or recursive-API traversal emits one info-level summary with counts for successful mirror resolutions, missing-origin fallbacks, malformed-metadata fallbacks, and cycles. A resolution attempt is a mirror with a non-null origin or malformed metadata; null origins are not failures. The failed-resolution count is the sum of missing-origin, malformed-metadata, and cycle counts. When at least one resolution was attempted and failures are 50% or more of attempts, the traversal also emits a warning containing the counts, failure ratio, source label, and operation. Contextual fallback warnings and consolidated cycle warnings remain in addition to this aggregate instrumentation.
+
+For CLI invocations, the threshold warning is written to stderr through `slog.Warn`. For MCP get, list, and search results, the same warning is also prepended as a text content block before the normal JSON content block, leaving the normal JSON payload unchanged. Server logging alone does not satisfy MCP user visibility. Unit tests assert both stderr logging and the additional MCP content block; below-threshold MCP results retain their existing single JSON content block.
+
+Debug logs include the mirror-resolution and search-occurrence choices at invocation start. Resolved-tree indexing logs source-root, node, and mirror counts. Traversal logs its scope, target, requested depth, effective depth, and operation; progress is reported at exponentially increasing occurrence thresholds so accelerating growth is visible without logging every node. Traversal progress includes visited occurrences, current and maximum path depth, elapsed time, heap bytes, heap objects, total allocated bytes, and garbage-collection count. Fetch completion defines retained occurrences as freshly materialized output nodes. Each search visitor result reports its current retained-match count after deduplication and any mirror-to-original replacement, allowing traversal completion to log the final value. Each resolved-tree instance owns its memory-stat reader; the production constructor uses Go runtime statistics, while tests inject an instance-specific reader without mutable package state. Memory statistics are read only when debug logging is enabled. Existing HTTP logs identify the selected deployment and request path, including `/nodes/:id/mirror`.
+
+## Testing
+
+### Mirror metadata and resolved trees
+
+Unit tests cover:
+
+- beta `origin_id`, backup `originalId`, null origin, origin-only `mirror_ids`/`mirrorRootIds`, ordinary nodes, and malformed recognized origin fields;
+- ordinary source children;
+- resolved mirror children replacing, not merging with, source children;
+- disabled resolution making every recognized mirror a leaf;
+- missing origin fallback and contextual warning;
+- nested mirrors;
+- path-local cycle detection and warning;
+- aggregate resolution counts, CLI stderr delivery, MCP result delivery, and the 50% failed-resolution warning threshold;
+- repeated independent occurrences of one origin;
+- depth zero, finite depth, and unlimited depth;
+- source-tree items and child slices remaining unchanged after fetch, flatten, and search.
+- targeted fetch avoiding unrelated roots and respecting requested depth during its first traversal;
+- streaming search retaining matches rather than every visited occurrence;
+- a completed occurrence not suppressing a later open mirror occurrence;
+- a cycle-truncated occurrence not suppressing a later path with a different cycle boundary;
+- debug indexing, traversal-progress, completion, and Go-heap attributes.
+
+### Direct API fetching
+
+Local HTTP-server tests cover:
+
+- direct mirror retrieval with resolution disabled makes no child request;
+- recursive root fetching skips child requests beneath mirror results when disabled;
+- ordinary nodes recurse when mirror metadata is absent;
+- enabled behavior retains server-resolved mirror children;
+- production and beta clients use identical metadata-driven logic.
+
+### Search
+
+CLI and MCP tests cover:
+
+- `resolve_mirrors` defaults true and is exposed on get, list, and search;
+- `search_mirrors` defaults false and is search-only;
+- conflicting options fail before traversal;
+- mirror-only content is searched;
+- default results deduplicate multiple mirror roots and descendant occurrences;
+- an in-scope original occurrence wins over mirrors;
+- the first source-priority mirror wins when the original is outside scope;
+- `search_mirrors=true` returns all in-scope occurrences and paths;
+- flat, parent/path/date grouped, and tree outputs follow the same occurrence policy;
+- tree output retains distinct branches with repeated node IDs by keying traversal state on occurrence identity.
+
+### Mirror mutation
+
+Client, CLI, and MCP tests cover:
+
+- exact request method, path, body, and response decoding;
+- full/short/URL input resolution and root rejection;
+- `top`, `bottom`, and invalid position;
+- selected deployment routing with no beta gate;
+- production or beta API failures preserved and wrapped contextually;
+- source read-root validation;
+- effective destination write-root validation when the requested parent is a mirror;
+- mirror-of-mirror response where `origin_id` differs from requested `id`;
+- exact MCP schema, centralized API dispatch, expose groups, and aliases;
+- existing delete remains the documented mirror-removal path.
+
+Race tests verify that concurrent resolved-tree reads, searches with different occurrence policies, and MCP calls with different deployments/options do not share mutable invocation state.
+
+### Integration tests
+
+Read-only integration tests use explicitly configured mirror IDs to compare beta `get` and `export` descendants and to verify `resolve_mirrors=false` returns a mirror leaf. They remain under `just test-integration` and skip when mirror fixtures are not configured.
+
+An optional destructive integration test creates a mirror under an explicitly configured test parent, verifies `item_id` and `origin_id`, and deletes the created mirror during cleanup. It belongs under `just test-integration-write`, skips without dedicated source/parent IDs, and must never target root or user data inferred by the test.
+
+## Documentation
+
+The implementation updates:
+
+- `docs/architecture.md` with stable source-tree and resolved-tree decisions;
+- README examples and MCP tool inventory;
+- `docs/CLI.md` for `resolve-mirrors`, `search-mirrors`, and `workflowy mirror`;
+- `docs/MCP.md` for matching properties, defaults, occurrence behavior, and `workflowy_mirror`;
+- command/tool help and schemas;
+- `CHANGELOG.md`;
+- a feature release post under the repository's existing documentation convention, or `docs/blog/` if no convention exists.
+
+Documentation states that mirror behavior is metadata-driven, beta currently supplies the documented metadata and mutation endpoint, production is not locally blocked, and the selected deployment's actual response is authoritative.
+
+## Alternatives Rejected
+
+### Eager source-tree mutation
+
+Attaching origin children directly to mirror nodes would affect reports, transforms, validation, and later callers. Shared child pointers would also make depth limiting and flattening order-dependent.
+
+### Separate fetch and search resolution
+
+Duplicating mirror traversal in handlers would repeat nested-mirror, missing-origin, cycle, and depth behavior across CLI and MCP.
+
+### Full resolved-scope occurrence materialization
+
+Building a slice containing every occurrence before selecting a fetch result or evaluating a search pattern retains copied ancestor paths, expansion paths, and identity strings for unrelated nodes. Path-local cycle detection cannot prevent combinatorial growth across distinct non-cyclic paths. The resolved-tree module instead performs operation-specific traversal over the source tree and retains only requested output.
+
+### Deployment-gated mirror support
+
+Hardcoding beta would require an application change when Workflowy promotes mirror behavior to production and would duplicate capability knowledge already present in response metadata or the selected API's response.
+
+### Transport switching when resolution is disabled
+
+Forcing export when `get` is selected would make a descendant option unexpectedly change transport and rate-limit behavior. Mirror metadata on retrieved nodes is sufficient to stop child requests locally.
+
+### Mirror-specific removal command
+
+Workflowy's ordinary delete endpoint removes a mirror without deleting its origin, and the repository already exposes delete consistently across CLI and MCP.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,6 +11,7 @@ Complete command-line reference for the Workflowy CLI tool.
 - [Setup](#setup)
   - [Get Your API Key](#get-your-api-key)
 - [Global Options](#global-options)
+- [API Selection](#api-selection)
 - [Full and Short IDs](#full-and-short-ids)
 - [Available Commands](#available-commands)
   - [get](#workflowy-get)
@@ -25,6 +26,7 @@ Complete command-line reference for the Workflowy CLI tool.
   - [search](#workflowy-search)
   - [replace](#workflowy-replace)
   - [targets](#workflowy-targets)
+  - [id](#workflowy-id)
   - [report](#report-commands)
   - [mcp](#mcp-server)
 - [Data Access Methods](#data-access-methods)
@@ -79,6 +81,18 @@ These options apply to all commands:
 | `--force-refresh` | Bypass cache (for `--method=export`) | `false` |
 | `--write-root-id <id>` | Restrict write operations to this node and descendants | - |
 | `--read-root-id <id>` | Restrict all operations to this node and descendants | - |
+
+## API Selection
+
+Commands that can construct a Workflowy client accept the command-local option `--api <production|beta>`. It defaults to `production`, rejects every other value, and appears after the subcommand:
+
+```bash
+workflowy get --api=beta
+workflowy create "Beta node" --api=beta
+workflowy mcp --api=beta
+```
+
+The option is available on `get`, `list`, `create`, `update`, `move`, `delete`, `complete`, `uncomplete`, `targets`, `search`, `replace`, `transform`, `id`, `mcp`, and every `report` subcommand. It is intentionally absent from the local-only `version` command. `workflowy --api=beta get` is not supported because this is not a global option.
 
 ### Read Restrictions
 
@@ -217,6 +231,7 @@ workflowy get <item-id> --method=backup
 | `--include-ancestors` | Wrap result in ancestor path from root to target node | `false` |
 | `--ancestor-depth <n>` | Include N levels of ancestors (-1 for all, 0 for none) | `0` |
 | `--to-ancestor <id>` | Include ancestors up to and including this node ID | - |
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
 
 **Smart API Selection:**
 - Depth 1-3: Uses GET API (efficient for shallow fetches)
@@ -287,6 +302,7 @@ workflowy create --parent-id <parent-id> --position top "New item"
 | `--note <text>` | Note content | - |
 | `--position <top\|bottom>` | Position in parent | `bottom` |
 | `--layout-mode <mode>` | Layout: bullets, todo, h1, h2, h3 | `bullets` |
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
 
 ---
 
@@ -312,6 +328,7 @@ workflowy update <item-id> --name "new title" --note "new note"
 | `--name <text>` | New node name |
 | `--note <text>` | New note content |
 | `--layout-mode <mode>` | Layout: bullets, todo, h1, h2, h3 |
+| `--api <production\|beta>` | Workflowy API deployment (default: `production`) |
 
 ---
 
@@ -326,6 +343,8 @@ workflowy delete <item-id>
 workflowy delete <item-id> --format json
 ```
 
+**API option:** `--api <production|beta>` (default: `production`)
+
 ---
 
 ### workflowy complete
@@ -336,6 +355,8 @@ Mark a node as complete.
 workflowy complete <item-id>
 ```
 
+**API option:** `--api <production|beta>` (default: `production`)
+
 ---
 
 ### workflowy uncomplete
@@ -345,6 +366,8 @@ Mark a node as incomplete.
 ```bash
 workflowy uncomplete <item-id>
 ```
+
+**API option:** `--api <production|beta>` (default: `production`)
 
 ---
 
@@ -368,6 +391,7 @@ workflowy move <item-id> inbox
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--position <top\|bottom>` | Position in new parent | `top` |
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
 
 ---
 
@@ -432,6 +456,7 @@ workflowy transform <item-id> uppercase --interactive
 | `-b, --by` | Group by: modified, created, modified.<unit>, created.<unit> | `created.day` |
 | `-o, --order` | Group sort: +modified, -modified, +created, -created | `-modified` |
 | `--as-child` | Insert result as child node | `false` |
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
 
 ---
 
@@ -460,6 +485,45 @@ workflowy create --parent-id=inbox "New task"
 # Get contents of a shortcut
 workflowy get home
 ```
+
+**API option:** `--api <production|beta>` (default: `production`)
+
+---
+
+### workflowy id
+
+Resolve a short ID or target key to its full UUID using the selected deployment.
+
+```bash
+workflowy id 7ae1be810d4f
+workflowy id inbox --api=beta
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
+| `--api-key-file <path>` | API key file location | `~/.workflowy/api.key` |
+
+---
+
+### MCP Server
+
+Start the stdio MCP server.
+
+```bash
+workflowy mcp
+workflowy mcp --expose=all --api=beta
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--api <production\|beta>` | Default Workflowy API deployment | `production` |
+| `--expose <tools>` | `read`, `write`, `all`, or comma-separated tools | `read` |
+| `--method <get\|export\|backup>` | Default access method | auto |
+| `--backup-file <path>` | Backup used by backup method | latest backup |
+| `--read-root-id <id>` | Restrict reads and writes to a subtree | root |
+| `--write-root-id <id>` | Restrict writes to a subtree | root |
+| `--api-key-file <path>` | API key file location | `~/.workflowy/api.key` |
 
 ---
 
@@ -522,6 +586,7 @@ workflowy search "meeting" --format json
 | `-g, --group-by <mode>` | Group results: `parent`, `path`, `tree`, `modified.<unit>`, `created.<unit>` | - |
 | `--path-max-length <n>` | Max chars per path segment when using `--group-by=path` | `20` |
 | `-o, --order-by <field>` | Sort by: `match`, `parent`, `path`, `modified`, `created` (prefix `+`/`-` for asc/desc) | - |
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
 
 **Group-by units:** `year`, `month`, `day`, or a Go time format string.
 
@@ -568,6 +633,7 @@ workflowy replace --parent-id abc-123-def --depth 3 "pattern" "replacement"
 | `--interactive` | Confirm each replacement | `false` |
 | `--parent-id <id>` | Limit to subtree | root |
 | `--depth <n>` | Traversal depth (-1 unlimited) | `-1` |
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
 
 **Substitution syntax:** `$1`, `$2` or `${1}`, `${2}` for capture groups.
 
@@ -582,6 +648,7 @@ All report commands support these upload options:
 | `--upload` | Upload to Workflowy instead of printing | `false` |
 | `--parent-id <id>` | Parent for uploaded report | root |
 | `--position <top\|bottom>` | Position in parent | `top` |
+| `--api <production\|beta>` | Workflowy API deployment | `production` |
 
 ### workflowy report count
 
@@ -695,6 +762,20 @@ workflowy report mirrors --top-n 10
 
 ## Data Access Methods
 
+### API Deployment vs. Access Method
+
+`--api` chooses the Workflowy deployment. `--method` independently chooses whether reads and validation use direct GET requests, the export endpoint, or a local backup.
+
+```bash
+# Read directly from beta
+workflowy get --api=beta --method=get --depth=0
+
+# Read and validate offline, then upload the report through beta
+workflowy report count --api=beta --method=backup --upload
+```
+
+A read-only backup command remains offline. A backup-backed write, transform, replacement, or report upload uses the deployment selected by `--api` for its mutation.
+
 ### GET API (`--method=get`)
 
 - **When used**: Default for depth 1-3
@@ -705,7 +786,8 @@ workflowy report mirrors --top-n 10
 
 - **When used**: Default for depth ≥4 or `--all`
 - **Characteristics**: Single API call, cached locally
-- **Cache location**: `~/.workflowy/export-cache.json`
+- **Production cache**: `~/.workflowy/export-cache.json`
+- **Beta cache**: `~/.workflowy/export-cache-beta.json`
 - **Best for**: Full tree access, deep fetches
 
 ```bash

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -789,6 +789,16 @@ workflowy report count --method=backup
 
 ## Troubleshooting
 
+### HTTP Request Logging
+
+Use debug logging to show the HTTP method and path for every API request:
+
+```bash
+workflowy get <id> --log=debug
+```
+
+HTTP debug logs never include the API key, authorization header, or request body.
+
 ### Rate Limiting
 
 If you encounter rate limit errors:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -768,7 +768,7 @@ workflowy report mirrors --top-n 10
 
 ```bash
 # Read directly from beta
-workflowy get --api=beta --method=get --depth=0
+workflowy get --api=beta --method=get --depth=1
 
 # Read and validate offline, then upload the report through beta
 workflowy report count --api=beta --method=backup --upload

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -772,7 +772,7 @@ workflowy mcp --log=debug --log-file=/tmp/workflowy-mcp.log
 At debug level, every Workflowy API request logs its HTTP method and path:
 
 ```text
-DEBUG: http request (method='GET', path='/nodes/example')
+DEBUG: http request (method='GET' path='/nodes/example')
 ```
 
 HTTP debug logs never include the API key, authorization header, or request body.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -769,6 +769,14 @@ tail -f /tmp/workflowy-mcp.log
 workflowy mcp --log=debug --log-file=/tmp/workflowy-mcp.log
 ```
 
+At debug level, every Workflowy API request logs its HTTP method and path:
+
+```text
+DEBUG: http request (method='GET', path='/nodes/example')
+```
+
+HTTP debug logs never include the API key, authorization header, or request body.
+
 ---
 
 ## Security Considerations

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -13,6 +13,7 @@ Connect AI assistants like Claude, ChatGPT, and other MCP-compatible clients to 
   - [workflowy_list](#workflowy_list)
   - [workflowy_search](#workflowy_search)
   - [workflowy_targets](#workflowy_targets)
+  - [workflowy_id](#workflowy_id)
   - [workflowy_create](#workflowy_create)
   - [workflowy_update](#workflowy_update)
   - [workflowy_move](#workflowy_move)
@@ -27,6 +28,8 @@ Connect AI assistants like Claude, ChatGPT, and other MCP-compatible clients to 
   - [workflowy_report_modified](#workflowy_report_modified)
   - [workflowy_report_mirrors](#workflowy_report_mirrors)
 - [Exposure Modes](#exposure-modes)
+- [API Deployment](#api-deployment)
+- [Access Method](#access-method)
 - [Sandboxed Access](#sandboxed-access)
 - [Example Conversations](#example-conversations)
   - [Finding Information](#finding-information)
@@ -113,6 +116,9 @@ The server uses stdio transport. Start it with:
 
 ```bash
 workflowy mcp --expose=all
+
+# Make beta the server-wide default
+workflowy mcp --expose=all --api=beta
 ```
 
 Configure your MCP client to run this command and communicate via stdin/stdout.
@@ -138,6 +144,7 @@ Get a node and its descendants as a tree structure.
 | `include_ancestors` | boolean | Wrap result in ancestor path from root to target node (requires export or backup method) | `false` |
 | `ancestor_depth` | number | Include N levels of ancestors (-1 for all, 0 for none; requires export or backup method) | `0` |
 | `to_ancestor` | string | Include ancestors up to and including this node ID (requires export or backup method) | - |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method: get, export, or backup | auto |
 
 Only one ancestor parameter may be used at a time. When used, `include_ancestors` is equivalent to `ancestor_depth=-1`.
@@ -159,6 +166,7 @@ List descendants as a flat list.
 | `item_id` | string | Node ID or target name | root |
 | `depth` | number | Recursion depth (-1 for all) | `2` |
 | `include_empty_names` | boolean | Include empty-named items | `false` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method: get, export, or backup | auto |
 
 **Example prompt:** "List all items in my inbox"
@@ -180,6 +188,7 @@ Search nodes by text or regex pattern. Completed nodes (and their descendants) a
 | `group_by` | string | Group results: `parent`, `path`, `tree`, `modified.<unit>`, `created.<unit>` | - |
 | `path_max_length` | number | Max chars per path segment when using `group_by=path` | `20` |
 | `order_by` | string | Sort by: `match`, `parent`, `path`, `modified`, `created` (prefix `+`/`-` for asc/desc) | - |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method: get, export, or backup | export |
 
 **Group-by units:** `year`, `month`, `day`, or a Go time format string.
@@ -199,6 +208,7 @@ List available shortcuts and system targets. Also returns write restriction info
 **Parameters:**
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for resolving root names | auto |
 
 **Returns:**
@@ -206,6 +216,20 @@ List available shortcuts and system targets. Also returns write restriction info
 - `write_root`: (optional) Object with `id` and `name` of the write-restricted area
 
 **Example prompt:** "What shortcuts do I have in Workflowy?"
+
+---
+
+#### workflowy_id
+
+Resolve a short ID or target key to a full UUID using the selected deployment.
+
+**Parameters:**
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `id` | string | ID or target key to resolve | required |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
+
+**Example prompt:** "Resolve this Workflowy short ID using beta"
 
 ---
 
@@ -219,6 +243,7 @@ Generate a descendant count report showing where most content lives.
 | `item_id` | string | Root node for report | root |
 | `threshold` | number | Minimum ratio (0.0-1.0) | `0.01` |
 | `preserve_tags` | boolean | Keep HTML tags | `false` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method: get, export, or backup | export |
 
 **Example prompt:** "Where is most of my content in Workflowy?"
@@ -235,6 +260,7 @@ Rank nodes by immediate children count.
 | `item_id` | string | Root node for report | root |
 | `top_n` | number | Number of results | `20` |
 | `preserve_tags` | boolean | Keep HTML tags | `false` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method: get, export, or backup | export |
 
 **Example prompt:** "Which nodes have the most children?"
@@ -251,6 +277,7 @@ Rank nodes by creation date (oldest first).
 | `item_id` | string | Root node for report | root |
 | `top_n` | number | Number of results | `20` |
 | `preserve_tags` | boolean | Keep HTML tags | `false` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method: get, export, or backup | export |
 
 **Example prompt:** "What are my oldest notes?"
@@ -267,6 +294,7 @@ Rank nodes by modification date (oldest first).
 | `item_id` | string | Root node for report | root |
 | `top_n` | number | Number of results | `20` |
 | `preserve_tags` | boolean | Keep HTML tags | `false` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method: get, export, or backup | export |
 
 **Example prompt:** "Find notes I haven't touched in a while"
@@ -276,6 +304,8 @@ Rank nodes by modification date (oldest first).
 #### workflowy_report_mirrors
 
 Rank nodes by mirror count (most mirrored first). Uses backup file as mirror data is only available there.
+
+This backup-only tool intentionally has no `api` parameter and makes no API request.
 
 **Parameters:**
 | Parameter | Type | Description | Default |
@@ -303,6 +333,7 @@ Create a new node.
 | `note` | string | Note content | - |
 | `position` | string | `top` or `bottom` | `bottom` |
 | `layout_mode` | string | bullets, todo, h1, h2, h3 | `bullets` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for validation (writes use API) | auto |
 
 **Example prompts:**
@@ -322,6 +353,7 @@ Update an existing node.
 | `name` | string | New name | - |
 | `note` | string | New note | - |
 | `layout_mode` | string | bullets, todo, h1, h2, h3 | - |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for validation (writes use API) | auto |
 
 **Example prompt:** "Update the note on that item to include today's date"
@@ -338,6 +370,7 @@ Move a node to a new parent.
 | `id` | string | Node ID to move | required |
 | `parent_id` | string | Destination parent ID or target | required |
 | `position` | string | `top` or `bottom` | `top` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for validation (writes use API) | auto |
 
 **Example prompts:**
@@ -354,6 +387,7 @@ Delete a node and its children.
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `id` | string | Node ID to delete | required |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for validation (writes use API) | auto |
 
 **Example prompt:** "Delete that completed task"
@@ -368,6 +402,7 @@ Mark a node as complete.
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `item_id` | string | Node ID to complete | required |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for validation (writes use API) | auto |
 
 **Example prompt:** "Mark that task as done"
@@ -382,6 +417,7 @@ Mark a node as incomplete.
 | Parameter | Type | Description | Default |
 |-----------|------|-------------|---------|
 | `item_id` | string | Node ID to uncomplete | required |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for validation (writes use API) | auto |
 
 **Example prompt:** "Uncheck that task"
@@ -401,6 +437,7 @@ Bulk find-and-replace text in node names.
 | `depth` | number | Traversal depth (-1 unlimited) | `-1` |
 | `ignore_case` | boolean | Case-insensitive | `false` |
 | `dry_run` | boolean | Preview without applying | `true` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for reading (writes use API) | export |
 
 **Example prompts:**
@@ -429,6 +466,7 @@ Transform node names and/or notes using built-in or shell transformations.
 | `note` | boolean | Transform node notes | `false` |
 | `dry_run` | boolean | Preview without applying | `true` |
 | `as_child` | boolean | Insert result as child | `false` |
+| `api` | string | Workflowy API deployment: `production` or `beta` | server default |
 | `method` | string | Access method for reading (writes use API) | export |
 
 **Example prompts:**
@@ -466,6 +504,29 @@ workflowy mcp --expose=get,list,search,create
 ```
 
 ---
+
+## API Deployment
+
+The server flag `--api=production|beta` establishes the default deployment. Production is the default when the flag is omitted. Every network-capable tool also accepts an optional `api` argument, with this precedence:
+
+```text
+tool api argument > server --api flag > production
+```
+
+For example, this call uses beta even when the server default is production:
+
+```json
+{"id": "None", "depth": 0, "method": "get", "api": "beta"}
+```
+
+`api` chooses the Workflowy deployment; `method` independently chooses the read and validation source. With `method=backup`, full UUIDs and unique 12-character short IDs resolve from the local tree. Target keys such as `inbox` require an API and therefore cannot be used as restriction roots in offline backup mode. Read-only backup calls remain offline, while writes still use the deployment selected by `api`.
+
+Export caches are isolated:
+
+- Production: `~/.workflowy/export-cache.json`
+- Beta: `~/.workflowy/export-cache-beta.json`
+
+`workflowy_report_mirrors` is the sole backup-only tool and intentionally does not expose `api`.
 
 ## Access Method
 

--- a/docs/plans/2026-08-04-mirror-support.md
+++ b/docs/plans/2026-08-04-mirror-support.md
@@ -1,0 +1,1001 @@
+# Workflowy Mirror Support Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make get, list, and search mirror-aware across API, export, and backup sources, and add matching CLI and MCP mirror-creation commands.
+
+**Architecture:** Add an immutable resolved-tree view beside the existing source-tree helpers. It normalizes mirror metadata, selects node occurrences inside a resolved read scope, materializes only requested fetch output, and streams occurrences to a single search pipeline; reports, transforms, and write validation retain source-tree behavior. Direct API recursion uses the same metadata rules, while mirror creation remains a thin deployment-neutral client operation with source-tree access checks.
+
+**Tech Stack:** Go 1.24, urfave/cli/v3, mcp-go, `log/slog`, testify, `httptest`, bats, just.
+
+**Reference:** Implement against `docs/2026-08-04-mirror-support-design.md` and keep `docs/architecture.md` synchronized.
+
+**Starting point:** Create the implementation branch from `6aa849e24ce9066d8ef3088d6964f72d7c4a3e2a` (`fix: complete Workflowy API selection behavior`). Commit the design and this plan on that branch before implementation. Do not replay the previous materialized-tree implementation commits.
+
+---
+
+## Chunk 1: Mirror model and resolved traversal
+
+### Task 0: Record the quality baseline
+
+**Files:**
+- Test: all Go packages
+
+- [ ] **Step 1: Verify the starting branch**
+
+Run: `git branch --show-current && git status --short`
+
+Expected: branch `feat/mirror-support-on-demand`, based on `6aa849e24ce9066d8ef3088d6964f72d7c4a3e2a`, with no uncommitted files.
+
+- [ ] **Step 2: Record tests and coverage before implementation**
+
+Run: `just test && go test ./... -coverprofile=/tmp/workflowy-mirror-baseline-cover.out && go tool cover -func=/tmp/workflowy-mirror-baseline-cover.out | tail -1 | tee /tmp/workflowy-mirror-baseline-coverage.txt`
+
+Expected: PASS; `/tmp/workflowy-mirror-baseline-coverage.txt` contains the starting total coverage percentage for the final comparison.
+
+### Task 1: Normalize mirror metadata into a rich result
+
+**Files:**
+- Create: `pkg/workflowy/mirror_reference.go`
+- Create: `pkg/workflowy/mirror_reference_test.go`
+
+- [ ] **Step 1: Write table-driven mirror classification tests**
+
+Cover these exact cases in `TestMirrorReferenceFromItem`: beta string `origin_id`, backup string `originalId`, each recognized field set to `nil`, each recognized field with a non-string value, origin-only `mirror_ids`, origin-only `mirrorRootIds`, a non-object `mirror` value, missing `data`, and an ordinary data object. Assert the full result, not a boolean.
+
+```go
+type MirrorReferenceKind uint8
+
+const (
+	MirrorReferenceOrdinary MirrorReferenceKind = iota
+	MirrorReferenceWithOrigin
+	MirrorReferenceNullOrigin
+	MirrorReferenceMalformed
+)
+
+type MirrorReference struct {
+	Kind     MirrorReferenceKind
+	OriginID string
+	Field    string
+	ValueType string
+}
+```
+
+Assert that `mirror_ids`, `mirrorRootIds`, and a non-object `mirror` value are ordinary; only a present `origin_id` or `originalId` with an unexpected type is malformed.
+
+- [ ] **Step 2: Run the focused test and verify the missing symbols fail**
+
+Run: `go test ./pkg/workflowy -run TestMirrorReferenceFromItem -count=1`
+
+Expected: FAIL because `MirrorReferenceFromItem` and its result types do not exist.
+
+- [ ] **Step 3: Implement the metadata accessor**
+
+Implement `MirrorReferenceFromItem(item *Item) MirrorReference` with early returns. Check `origin_id` before `originalId`, preserve the recognized field name in the result, use `fmt.Sprintf("%T", value)` for malformed type context, and add:
+
+```go
+func (reference MirrorReference) IsMirror() bool {
+	return reference.Kind != MirrorReferenceOrdinary
+}
+```
+
+Do not inspect `APIDeployment`, log, or traverse children in this file.
+
+- [ ] **Step 4: Run the package tests**
+
+Run: `go test ./pkg/workflowy -run 'TestMirrorReference' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the metadata model**
+
+```bash
+git add pkg/workflowy/mirror_reference.go pkg/workflowy/mirror_reference_test.go
+git commit -m "feat: normalize Workflowy mirror references"
+```
+
+### Task 2: Build the on-demand resolved-tree module
+
+**Files:**
+- Create: `pkg/workflowy/resolved_tree.go`
+- Create: `pkg/workflowy/resolved_tree_traversal.go`
+- Create: `pkg/workflowy/resolved_tree_diagnostics.go`
+- Create: `pkg/workflowy/resolved_tree_fetch_test.go`
+- Create: `pkg/workflowy/resolved_tree_visit_test.go`
+- Create: `pkg/workflowy/resolved_tree_diagnostics_test.go`
+
+- [ ] **Step 1: Write failing index, child-rule, and bounded-fetch tests**
+
+Create fixtures with an origin, source children, two mirror roots, a null-origin mirror, a malformed mirror, a missing-origin mirror, and unrelated roots. Add tests covering:
+
+- available origin children replace rather than merge with mirror source children;
+- disabled resolution makes every recognized mirror a leaf;
+- null, missing, and malformed origins use source children when enabled;
+- root and node fetches return fresh values without mutating the source tree;
+- depth zero, finite depth, and unlimited depth;
+- a targeted fetch does not traverse an unrelated mirror cycle;
+- a depth-zero root fetch does not inspect deeper mirror cycles;
+- a source child replaced by mirror resolution is not reachable;
+- a reachable original occurrence is preferred;
+- the first source-priority mirror occurrence is selected when no original is reachable;
+- source descendants beneath null, missing, or malformed mirror fallbacks remain mirror-path occurrences and do not outrank a truly original occurrence;
+- materializing a selected descendant preserves every source ID active above it, so a descendant mirror back to an already-active origin stops immediately;
+- a mirror-target fetch counts each resolution and cycle encounter once across selection and materialization, with exact `Resolved` and `Cycles` assertions.
+
+Use this public fetch interface from the first test:
+
+```go
+type ResolveOptions struct {
+	ResolveMirrors bool
+	Depth          int
+	Operation      string
+}
+
+type MirrorResolutionSummary struct {
+	Resolved          int
+	MissingOrigin     int
+	MalformedMetadata int
+	Cycles            int
+}
+
+type ResolvedFetch struct {
+	Item       *Item
+	Items      []*Item
+	Occurrence NodeOccurrence
+	Summary    MirrorResolutionSummary
+}
+
+tree := NewResolvedTree(sourceRoots, "test export")
+result, err := tree.Fetch("None", mirrorID, ResolveOptions{
+	ResolveMirrors: true,
+	Depth:          -1,
+	Operation:      "get",
+})
+```
+
+`targetID == "None"` populates `Items`; a node target populates `Item` and `Occurrence`. For immutability, snapshot source JSON, mutate the returned fetch through `FlattenTree` and `FilterEmptyItem`, and assert the source JSON is unchanged.
+
+- [ ] **Step 2: Run the bounded-fetch tests and verify failure**
+
+Run: `go test ./pkg/workflowy -run 'TestResolvedTreeFetch' -count=1`
+
+Expected: FAIL because `ResolvedTree` and its fetch interface do not exist.
+
+- [ ] **Step 3: Implement one source index and target-directed fetch**
+
+In `resolved_tree.go`, index every source item once as a private node containing the item and its source parent. Use that single index for origin lookup, source occurrence reconstruction, and restricted scope lookup. Do not maintain a second item map or recursively search a tree already represented by the index.
+
+Implement `Fetch` as operation-specific traversal:
+
+1. Resolve the requested read-scope source occurrence.
+2. For a root request, materialize each scope root directly at the requested depth.
+3. For a node request, reconstruct a possible original source path from the index and validate every parent-child edge with the resolved child rule.
+4. If that original occurrence is not reachable, traverse only until the first reachable mirror occurrence is found.
+5. Before selection traversal unwinds, return a private selection containing snapshots of the public occurrence's ancestors and the active source-ID path at that occurrence; neither may alias reusable traversal stacks.
+6. Materialize only the selected occurrence and requested descendant depth, continuing with that active path so cycle detection sees every source ID activated during selection.
+
+Use one operation-scoped summary and diagnostics tracker across selection and materialization. Selection accounts for mirror resolutions needed to reach the target; materialization accounts for the selected node and returned descendants. The selected occurrence itself must not be observed or counted twice merely because fetch has two phases. Do not build an occurrence slice, traverse unrelated roots after selection, or perform an unlimited selection pass before applying a finite requested depth. Return contextual errors such as:
+
+```go
+return nil, fmt.Errorf(
+	"Cannot find Workflowy node %q within resolved read scope %q from %s",
+	targetID,
+	readScopeID,
+	tree.sourceLabel,
+)
+```
+
+Place mirror child selection, target selection, materialization, and active-path helpers in `resolved_tree_traversal.go`. Keep source-tree mutation helpers in `tree.go` unchanged.
+
+- [ ] **Step 4: Run bounded-fetch tests and verify they pass**
+
+Run: `go test ./pkg/workflowy -run 'TestResolvedTreeFetch' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing streaming-visit and cycle tests**
+
+Add tests covering:
+
+- occurrence ancestor paths and occurrence identity;
+- equality ID uses an origin ID for a mirror and a node ID otherwise;
+- every descendant reached below a mirror has `ViaMirror=true`;
+- target scoping uses the same original-first, first-reachable-mirror selection as fetch;
+- self-mirror and nested-mirror cycles stop before repeating an active origin;
+- independent occurrences of the same origin remain traversable;
+- a cycle-truncated occurrence does not suppress a later path with a different cycle boundary;
+- every occurrence path is visited without returning or retaining a complete occurrence slice;
+- visitor errors stop traversal and retain their context.
+
+Use this streaming interface:
+
+```go
+type NodeOccurrence struct {
+	Item      *Item
+	Ancestors []*Item
+	ViaMirror bool
+}
+
+func (occurrence NodeOccurrence) Identity() string
+func (occurrence NodeOccurrence) EqualityID() string
+func (occurrence NodeOccurrence) Snapshot() NodeOccurrence
+
+type OccurrenceVisitResult struct {
+	RetainedOccurrences int
+}
+
+type OccurrenceVisitor func(NodeOccurrence) (OccurrenceVisitResult, error)
+
+func (tree *ResolvedTree) Visit(
+	readScopeID, targetID string,
+	options ResolveOptions,
+	visitor OccurrenceVisitor,
+) (MirrorResolutionSummary, error)
+```
+
+The occurrence passed to a visitor is valid only for that callback. `Snapshot` copies its ancestor path for a consumer that chooses to retain it. This lets non-matching search occurrences reuse traversal path storage without allocating copied ancestors and identity strings. `Identity` and `EqualityID` are computed only when a consumer needs them.
+
+- [ ] **Step 6: Run visit tests and verify failure**
+
+Run: `go test ./pkg/workflowy -run 'TestResolvedTreeVisit|TestNodeOccurrence' -count=1`
+
+Expected: FAIL because streaming traversal and occurrence helpers are absent.
+
+- [ ] **Step 7: Implement branch-local traversal without a collecting interface**
+
+Implement depth-first `Visit` in `resolved_tree_traversal.go`. Maintain reusable ancestor and active-source-ID stacks with push/pop ownership inside the traversal. Before following a mirror origin, stop when that origin is already active on the current path. Do not use a global visited set: completion filtering and cycle boundaries depend on occurrence ancestry, and independent paths remain valid.
+
+Expose no `Walk` method and no method that returns all occurrences. Fetch and search are the only required resolved-tree consumers. Search will retain snapshots only for selected matches in Task 6.
+
+- [ ] **Step 8: Run fetch and visit tests**
+
+Run: `go test ./pkg/workflowy -run 'TestResolvedTree|TestNodeOccurrence' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 9: Write failing observability tests**
+
+Add tests for `MirrorResolutionSummary.Attempts`, `Failures`, and `ThresholdWarning`; contextual missing-origin and malformed warnings; consolidated cycle warnings; and one info summary per public traversal. At debug level, assert:
+
+- indexing records source roots, source nodes, and mirrors;
+- traversal start/completion records operation, source, scope, target, requested/effective depth, visited occurrences, retained occurrences, current/maximum path depth, elapsed time, heap bytes, heap objects, total allocated bytes, and GC count;
+- progress occurs at 1,000, 2,000, 4,000, and subsequent doubling thresholds;
+- memory statistics are not read when debug logging is disabled.
+
+Give each tree an instance-owned memory-stat reader so tests replace it without package-global mutable state. Fetch retained occurrences equal materialized output nodes; Visit uses the most recent `OccurrenceVisitResult.RetainedOccurrences`. Add an exact completion-log regression for the mirror-target fixture from Step 1, proving selection and materialization do not double-count `visited_occurrences` or `retained_occurrences`.
+
+- [ ] **Step 10: Run diagnostics tests and verify failure**
+
+Run: `go test ./pkg/workflowy -run 'TestMirrorResolutionSummary|TestResolvedTree(Logs|DoesNotReadMemoryStats)' -count=1`
+
+Expected: FAIL because diagnostics are not implemented.
+
+- [ ] **Step 11: Implement traversal diagnostics from the outset**
+
+Implement diagnostics in `resolved_tree_diagnostics.go`. Read Go memory statistics only when debug logging is enabled. Log no node names, notes, or credentials. Consolidate repeated cycle warnings by mirror/origin pair while preserving the total cycle count. Emit the aggregate warning at a failure ratio of 50% or greater. Null origins are neither attempts nor failures.
+
+- [ ] **Step 12: Run workflowy tests and race detection**
+
+Run: `go test ./pkg/workflowy -count=1 && go test -race ./pkg/workflowy -count=1`
+
+Expected: PASS with no races.
+
+- [ ] **Step 13: Commit the on-demand resolved-tree module**
+
+```bash
+git add pkg/workflowy/resolved_tree.go pkg/workflowy/resolved_tree_traversal.go pkg/workflowy/resolved_tree_diagnostics.go pkg/workflowy/resolved_tree_fetch_test.go pkg/workflowy/resolved_tree_visit_test.go pkg/workflowy/resolved_tree_diagnostics_test.go
+git commit -m "feat: add on-demand Workflowy mirror traversal"
+```
+
+### Task 3: Make direct API recursion mirror-aware
+
+**Files:**
+- Create: `pkg/workflowy/recursive_fetch.go`
+- Create: `pkg/workflowy/recursive_fetch_test.go`
+- Modify: `pkg/workflowy/workflowy.go`
+- Modify: `pkg/workflowy/interfaces.go`
+- Modify: `pkg/workflowy/workflowy_test.go`
+- Modify: `cmd/workflowy/backup_api_test.go`
+- Modify: `cmd/workflowy/client_test.go`
+- Modify: `cmd/workflowy/count_report_test.go`
+- Modify: `pkg/mcp/api_selection_test.go`
+- Modify: `pkg/mcp/tools_test.go`
+
+- [ ] **Step 1: Write HTTP request-count tests**
+
+Using `httptest.Server`, add:
+
+- `TestRecursiveFetchDisabledDoesNotListMirrorChildren`
+- `TestRecursiveFetchNilRootRetrievesMirrorBeforeDisabledTraversal`
+- `TestRecursiveFetchRejectsMismatchedRootItem`
+- `TestRecursiveFetchDisabledStillListsOrdinaryChildren`
+- `TestRecursiveFetchEnabledUsesServerMirrorChildren`
+- `TestRecursiveFetchStopsMirrorCycle`
+- `TestRecursiveFetchInternalRootSeedsCyclePath`
+- `TestRecursiveFetchUsesMetadataForBothDeployments`
+
+Record every request path. For a retrieved mirror with resolution disabled, assert the node is returned unchanged and `/nodes?parent_id=<mirror>` is never requested. Repeat with `RootItem=nil`: assert one `GET /nodes/<mirror>` retrieves metadata before the child request is suppressed. For an ordinary root containing a mirror, assert recursion stops below that child only. Assert a supplied root whose ID differs from `itemID` makes no HTTP requests and returns the specified contextual `Cannot ...` error. Assert an internally retrieved root seeds the same active cycle path as a supplied root.
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run: `go test ./pkg/workflowy -run 'TestRecursiveFetch' -count=1`
+
+Expected: FAIL because the option-bearing fetch API does not exist.
+
+- [ ] **Step 3: Add the explicit recursive fetch contract**
+
+Move recursive traversal out of `workflowy.go` into `recursive_fetch.go` and add:
+
+```go
+type RecursiveFetchOptions struct {
+	Depth          int
+	ResolveMirrors bool
+	Operation      string
+	RootItem       *Item
+}
+
+type RecursiveFetchResult struct {
+	Response *ListChildrenResponse
+	Summary  MirrorResolutionSummary
+}
+
+ListChildrenRecursiveWithOptions(ctx context.Context, itemID string, options RecursiveFetchOptions) (*RecursiveFetchResult, error)
+```
+
+Keep `ListChildrenRecursive` and `ListChildrenRecursiveWithDepth` as compatibility wrappers with `ResolveMirrors: true`. Add the option-bearing method to `workflowy.Client`. For a non-root `itemID`, `ListChildrenRecursiveWithOptions` retrieves the root node internally when `RootItem` is nil; when `RootItem` is non-nil but its ID differs from `itemID`, return `Cannot recursively fetch Workflowy node <itemID>: supplied root item has ID <rootID>`. CLI and MCP handlers pass their already-retrieved item to avoid the extra request.
+
+- [ ] **Step 4: Write recursive observability tests before traversal implementation**
+
+Add `TestRecursiveFetchReturnsResolutionSummary`, `TestRecursiveFetchLogsOneTraversalSummary`, `TestRecursiveFetchLogsContextualMalformedFallback`, `TestRecursiveFetchLogsContextualCycle`, and `TestRecursiveFetchWarnsWhenAtLeastHalfOfAttemptsFail`. Capture `slog` records and assert the same count attributes and equations as `ResolvedTree`. Assert exactly one info summary for a public recursive call, individual malformed/cycle warnings contain item/origin/path context, and the threshold warning fires at 50% but not below it.
+
+- [ ] **Step 5: Run recursive observability tests and verify failure**
+
+Run: `go test ./pkg/workflowy -run 'TestRecursiveFetch(Returns|Logs|Warns)' -count=1`
+
+Expected: FAIL because option-bearing traversal and its instrumentation are not implemented.
+
+- [ ] **Step 6: Implement metadata checks and active-path state**
+
+Start the path with `RootItem` when the caller already retrieved a requested node. When non-root `RootItem` is nil, assign the internally retrieved node to the local root and seed the path exactly as if the caller supplied it. Root-list calls begin one path per returned top-level item. When resolution is disabled, do not list a recognized mirror's children. When enabled and a mirror has an available origin, reject it if the origin is already active; otherwise add that origin ID to a branch-local copy of the active path before listing and recursing beneath the mirror. Let the selected API's list response supply children, and discard the copied path when that branch returns. Return and log the same summary fields as local traversal.
+
+The compatibility wrappers may perform one additional `GetItem` for non-root IDs because they do not receive a `RootItem`; record this in their Go documentation.
+
+- [ ] **Step 7: Update test clients for the expanded interface**
+
+Add forwarding or recording implementations of `ListChildrenRecursiveWithOptions` to the fake clients in the files listed above. Do not weaken `workflowy.Client` with type assertions or optional runtime capability checks.
+
+- [ ] **Step 8: Run all unit tests**
+
+Run: `just test`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit direct API traversal**
+
+```bash
+git add pkg/workflowy/recursive_fetch.go pkg/workflowy/recursive_fetch_test.go pkg/workflowy/workflowy.go pkg/workflowy/interfaces.go pkg/workflowy/workflowy_test.go cmd/workflowy/backup_api_test.go cmd/workflowy/client_test.go cmd/workflowy/count_report_test.go pkg/mcp/api_selection_test.go pkg/mcp/tools_test.go
+git commit -m "feat: control mirror resolution for API reads"
+```
+
+## Chunk 2: Get, list, and search interface parity
+
+### Task 4: Wire mirror resolution into CLI get and list
+
+**Files:**
+- Modify: `cmd/workflowy/flags.go`
+- Modify: `cmd/workflowy/flags_test.go`
+- Modify: `cmd/workflowy/invocation.go`
+- Modify: `cmd/workflowy/fetch.go`
+- Modify: `cmd/workflowy/fetch_test.go`
+- Modify: `cmd/workflowy/read_guard.go`
+- Create: `cmd/workflowy/mirror_fetch_test.go`
+- Modify: `cmd/workflowy/transform_test.go`
+
+- [ ] **Step 1: Write flag and default tests**
+
+Assert `getFetchFlags()` contains a `resolve-mirrors` boolean flag with value `true`, and urfave accepts both `--resolve-mirrors=false` and `--resolve-mirrors=true`. Extend `FetchParameters` with `resolveMirrors bool` and assert parsing.
+
+- [ ] **Step 2: Run the flag tests and verify failure**
+
+Run: `go test ./cmd/workflowy -run 'Test.*ResolveMirrors.*Flag|TestGetAndValidateFetchParams' -count=1`
+
+Expected: FAIL because the flag is absent.
+
+- [ ] **Step 3: Add the shared CLI fetch flag**
+
+Add this command-local flag through `getFetchFlags` and reuse the same constructor from search:
+
+```go
+func getResolveMirrorsFlag() cli.Flag {
+	return &cli.BoolFlag{
+		Name:  "resolve-mirrors",
+		Value: true,
+		Usage: "Resolve mirror descendants",
+	}
+}
+```
+
+- [ ] **Step 4: Write export, backup, access, and API handler tests**
+
+Add CLI-level tests covering get and list defaults, explicit false, export mirror children, backup `originalId`, direct API request suppression, a descendant reachable only through a mirror beneath `read-root-id`, preferred original occurrence, first reachable mirror fallback, and fresh output across two invocations. Add `TestCommandInvocationRestrictedGetDoesNotTraverseUnrelatedMirrorBranches` with a restricted target followed by an unrelated mirror cycle inside the same read scope; assert validation succeeds without observing that cycle. For restricted direct GET, assert read-root validation and target selection share exactly one selected-deployment export snapshot. Add ancestor assertions proving a mirror-only reachable child receives its mirror path while an in-scope original wins when available. Add `TestTransformDoesNotTraverseResolvedMirrorChildren` before changing handlers: a dry-run transform at a mirror must omit origin descendants outside its source subtree. Add `TestGetMirrorThresholdWarningWritesStderr` and `TestGetMirrorBelowThresholdDoesNotWriteWarning`, capturing the command's log writer at exactly 50% and below it. Assert errors start with `Cannot` and contain target ID, read scope, and source.
+
+Add a counting export/backup provider and assert each restricted export or backup get/list invocation loads its source tree exactly once for ID resolution, read-scope validation, occurrence selection, and result materialization.
+
+- [ ] **Step 5: Run the new command tests and verify failure**
+
+Run: `go test ./cmd/workflowy -run 'Test((Get|List).*Mirror|CommandInvocationRestrictedGetDoesNotTraverseUnrelatedMirrorBranches|TransformDoesNotTraverseResolvedMirrorChildren)' -count=1`
+
+Expected: FAIL because fetch still reads and depth-limits the source tree.
+
+- [ ] **Step 6: Route fetches through the correct traversal**
+
+Add a distinct `commandInvocation.fetchResolvedItems`; do not change the source-tree `fetchItems` path used by transforms. Return a focused value:
+
+```go
+type mirrorFetchResult struct {
+	Value       any
+	SourceLabel string
+	Summary     workflowy.MirrorResolutionSummary
+}
+```
+
+Cache an invocation-scoped `sourceItems` and `sourceLabel` in `commandInvocation`. ID resolution, `ReadGuard`, and resolved fetching must use that same snapshot. For export and backup, construct `ResolvedTree` and call `Fetch`; do not call `FindItemInTree` or `LimitItemsDepth`. For GET, load the selected deployment export only when a read restriction requires reachability validation, validate the requested target through `ResolvedTree.Fetch` at depth zero, retrieve a non-root node once, then call `ListChildrenRecursiveWithOptions` using that item as `RootItem` and the CLI flag. Access-only validation must never enumerate the complete read scope.
+
+Make `ReadGuard` expose the resolved scope ID without independently rejecting a target by source-tree ancestry. Keep its existing source-tree validation methods for reports, transforms, and writes. For export/backup ancestor options, build the spine from the selected occurrence's ancestors and fresh materialized target, applying `ancestor-depth` and `to-ancestor` there. Keep `runTransform` on `invocation.fetchItems`; only get/list call `fetchResolvedItems`.
+
+- [ ] **Step 7: Run CLI tests**
+
+Run: `go test ./cmd/workflowy -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit CLI mirror-aware fetches**
+
+```bash
+git add cmd/workflowy/flags.go cmd/workflowy/flags_test.go cmd/workflowy/invocation.go cmd/workflowy/fetch.go cmd/workflowy/fetch_test.go cmd/workflowy/read_guard.go cmd/workflowy/mirror_fetch_test.go cmd/workflowy/transform_test.go
+git commit -m "feat: resolve mirrors in CLI fetch commands"
+```
+
+### Task 5: Wire mirror resolution and warnings into MCP get and list
+
+**Files:**
+- Create: `pkg/mcp/mirror_results.go`
+- Create: `pkg/mcp/mirror_results_test.go`
+- Create: `pkg/mcp/mirror_fetch.go`
+- Create: `pkg/mcp/mirror_fetch_test.go`
+- Modify: `pkg/mcp/tools.go`
+- Modify: `pkg/mcp/tools_test.go`
+
+- [ ] **Step 1: Write MCP schema and warning-result tests**
+
+Assert `workflowy_get` and `workflowy_list` expose boolean `resolve_mirrors` with default true. Test a helper that returns the existing single JSON content block below threshold and prepends one text warning block at or above threshold.
+
+```go
+func newMirrorAwareToolResultJSON(value any, summary workflowy.MirrorResolutionSummary, operation, source string) (*mcptypes.CallToolResult, error)
+```
+
+The warning text must equal `summary.ThresholdWarning(operation, source)` and the JSON block must be byte-for-byte equivalent to `mcptypes.NewToolResultJSON(value)`.
+
+- [ ] **Step 2: Run schema/result tests and verify failure**
+
+Run: `go test ./pkg/mcp -run 'Test.*ResolveMirrors|TestMirrorAwareToolResult' -count=1`
+
+Expected: FAIL because the schemas and helper are absent.
+
+- [ ] **Step 3: Add MCP properties and warning-result delivery**
+
+Add the `resolve_mirrors` schema property with default true to get and list and read it in their handlers. Implement only `newMirrorAwareToolResultJSON` in this step so warning content is testable before resolved-fetch handler integration. Do not yet replace handler traversal.
+
+- [ ] **Step 4: Write MCP behavior and concurrency tests**
+
+In `mirror_fetch_test.go`, cover export, backup, and GET; true and false; mirror-only read access; malformed/missing/cycle threshold warnings; and two parallel MCP calls selecting different APIs and resolution values. Add `TestToolBuilderRestrictedGetDoesNotTraverseUnrelatedMirrorBranches` with the same bounded access-validation assertion as CLI. For restricted direct GET, assert read-root validation and target selection share exactly one selected-deployment export snapshot. For ancestor-enabled get, assert a target reachable only through a mirror is allowed and its returned spine uses the chosen mirror occurrence; assert original preference when both paths are in scope. Use counting clients/providers to assert restricted export and backup get/list load one source snapshot. Assert no invocation tree, summary, or option leaks between calls.
+
+- [ ] **Step 5: Run MCP behavior tests and verify failure**
+
+Run: `go test ./pkg/mcp -run 'Test(.*Mirror|ToolBuilderRestrictedGetDoesNotTraverseUnrelatedMirrorBranches)' -count=1`
+
+Expected: FAIL because resolved fetching, bounded direct-GET validation, snapshot reuse, and ancestor routing are not implemented.
+
+- [ ] **Step 6: Implement resolved fetching in the focused file**
+
+In `mirror_fetch.go`, add `ToolBuilder.fetchResolvedItems`, returning value, source label, and summary while leaving the existing source-tree `fetchItems` for transform/write tools. Pass `resolve_mirrors` through local `ResolvedTree` and direct recursive fetch. Make `prepareInvocation` cache one invocation-scoped export or backup source snapshot when get/list needs local resolution or read-scope validation. `validateReadTarget`, occurrence selection, materialization, and `fetchItemWithAncestors` must reuse that snapshot rather than call `loadTree` independently. Route `fetchItemWithAncestors` through the occurrence selected by `ResolvedTree` so it returns that occurrence's ancestor spine. Use `ResolvedTree.Fetch` at depth zero for restricted direct-GET validation and `newMirrorAwareToolResultJSON` for get/list responses.
+
+- [ ] **Step 7: Run MCP tests with races**
+
+Run: `go test -race ./pkg/mcp -count=1`
+
+Expected: PASS with no races.
+
+- [ ] **Step 8: Commit MCP fetch parity**
+
+```bash
+git add pkg/mcp/mirror_results.go pkg/mcp/mirror_results_test.go pkg/mcp/mirror_fetch.go pkg/mcp/mirror_fetch_test.go pkg/mcp/tools.go pkg/mcp/tools_test.go
+git commit -m "feat: resolve mirrors in MCP fetch tools"
+```
+
+### Task 6: Search resolved occurrences once or at every mirror
+
+**Files:**
+- Create: `pkg/search/occurrences.go`
+- Create: `pkg/search/occurrences_test.go`
+- Modify: `pkg/search/search.go`
+- Modify: `pkg/search/search_test.go`
+- Modify: `pkg/search/tree.go`
+- Modify: `pkg/search/tree_test.go`
+- Modify: `cmd/workflowy/flags.go`
+- Modify: `cmd/workflowy/flags_test.go`
+- Modify: `cmd/workflowy/commands.go`
+- Modify: `cmd/workflowy/search.go`
+- Create: `cmd/workflowy/mirror_search_test.go`
+- Modify: `pkg/mcp/tools.go`
+- Modify: `pkg/mcp/tools_test.go`
+
+- [ ] **Step 1: Write failing incremental-matcher tests**
+
+Define an incremental matcher that receives one occurrence at a time. Test:
+
+- non-matches are discarded without taking an occurrence snapshot;
+- default deduplication uses `occurrence.EqualityID()`;
+- a later original occurrence replaces an earlier mirror occurrence;
+- the first mirror remains when no original is in scope;
+- `SearchMirrors=true` retains every matching occurrence;
+- completed ancestry filters only that occurrence path;
+- a completed occurrence cannot suppress a later open occurrence;
+- source-priority order remains stable;
+- flat, parent/path/date grouped, and tree views contain the same selected matches;
+- `SearchMirrors=true` keeps repeated Workflowy node IDs on distinct tree branches while serialized IDs remain unchanged.
+
+Use:
+
+```go
+type OccurrenceSearchOptions struct {
+	UseRegexp        bool
+	IgnoreCase       bool
+	IncludeCompleted bool
+	SearchMirrors    bool
+}
+
+type OccurrenceMatcher struct {
+	// private matcher and retained-match state
+}
+
+func NewOccurrenceMatcher(pattern string, options OccurrenceSearchOptions) *OccurrenceMatcher
+func (matcher *OccurrenceMatcher) Visit(workflowy.NodeOccurrence) (workflowy.OccurrenceVisitResult, error)
+func (matcher *OccurrenceMatcher) Matches() OccurrenceMatches
+
+type OccurrenceMatches struct {
+	matches []occurrenceMatch
+}
+
+func (matches OccurrenceMatches) Results() []Result
+func (matches OccurrenceMatches) Grouped(strategy GroupingStrategy) []GroupedResult
+func (matches OccurrenceMatches) Tree() []*TreeNode
+```
+
+`OccurrenceMatcher.Visit` snapshots an occurrence only when retaining it as a match. Do not add a public function that accepts a complete occurrence slice; no such compatibility interface exists at the restart point.
+
+- [ ] **Step 2: Run matcher tests and verify failure**
+
+Run: `go test ./pkg/search -run 'Test(OccurrenceMatcher|OccurrenceMatches)' -count=1`
+
+Expected: FAIL because the incremental occurrence matcher does not exist.
+
+- [ ] **Step 3: Implement matching, deduplication, and view adapters once**
+
+Implement pattern evaluation and deduplication in `occurrences.go`. Keep `occurrenceMatch` private. When a match is selected, retain `occurrence.Snapshot()` so later traversal stack reuse cannot alter its ancestors. For tree output, key internal branches by `occurrence.Identity()`; never key repeated paths only by Workflowy node ID.
+
+Keep existing source-tree `SearchItems`, `SearchItemsGroupedBy`, and `SearchItemsTree` behavior unchanged for non-mirror callers. Do not route source-tree compatibility functions through a new collecting occurrence layer.
+
+- [ ] **Step 4: Run all search tests**
+
+Run: `go test ./pkg/search -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write CLI and MCP streaming-search tests**
+
+Assert CLI search has `--resolve-mirrors=true|false` and `--search-mirrors`; MCP search has `resolve_mirrors` default true and `search_mirrors` default false. Both interfaces must reject false/true with exactly:
+
+```text
+Cannot search mirror occurrences when mirror resolution is disabled
+```
+
+Add end-to-end handler tests for mirror-only content, default original preference, first-mirror fallback, all matching occurrences, every grouping mode, and resolved read-root scoping. Add `TestSearchMirrorThresholdWarningWritesStderr`, `TestSearchMirrorBelowThresholdDoesNotWriteWarning`, `TestSearchCommandStreamsResolvedOccurrences`, and `TestSearchToolStreamsResolvedOccurrences`. Capture debug completion logs and assert many visited non-matches produce only the selected retained-match count. Use counting providers to assert each search loads one source snapshot.
+
+- [ ] **Step 6: Run handler tests and verify failure**
+
+Run: `go test ./cmd/workflowy ./pkg/mcp -run 'Test(.*Search.*Mirror|SearchCommandStreamsResolvedOccurrences|SearchToolStreamsResolvedOccurrences)' -count=1`
+
+Expected: FAIL until handlers stream `ResolvedTree` occurrences into the matcher.
+
+- [ ] **Step 7: Route both interfaces directly through `ResolvedTree.Visit`**
+
+Load export or backup source once into the invocation snapshot, construct one matcher, and pass `matcher.Visit` directly to `ResolvedTree.Visit`. Call exactly one match view after traversal. `search_mirrors` changes retained matches, not traversal: every occurrence path remains eligible because completed ancestry and cycle boundaries are path-local. Reject method `get` as today. Deliver threshold warnings through stderr for CLI and `newMirrorAwareToolResultJSON` for MCP. Remove independent source-tree target validation; resolved reachability is part of the same visit.
+
+- [ ] **Step 8: Run affected packages with races**
+
+Run: `go test -race ./pkg/workflowy ./pkg/search ./cmd/workflowy ./pkg/mcp -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit search occurrence support**
+
+```bash
+git add pkg/search/occurrences.go pkg/search/occurrences_test.go pkg/search/search.go pkg/search/search_test.go pkg/search/tree.go pkg/search/tree_test.go cmd/workflowy/flags.go cmd/workflowy/flags_test.go cmd/workflowy/commands.go cmd/workflowy/search.go cmd/workflowy/mirror_search_test.go pkg/mcp/tools.go pkg/mcp/tools_test.go
+git commit -m "feat: search Workflowy mirror occurrences"
+```
+
+## Chunk 3: Mirror creation
+
+### Task 7: Add the deployment-neutral mirror client operation
+
+**Files:**
+- Create: `pkg/workflowy/mirror_node.go`
+- Create: `pkg/workflowy/mirror_node_test.go`
+- Modify: `pkg/workflowy/interfaces.go`
+- Modify: `cmd/workflowy/backup_api_test.go`
+- Modify: `cmd/workflowy/client_test.go`
+- Modify: `cmd/workflowy/count_report_test.go`
+- Modify: `pkg/mcp/api_selection_test.go`
+- Modify: `pkg/mcp/tools_test.go`
+
+- [ ] **Step 1: Write request validation and HTTP contract tests**
+
+Test `SetPosition` for empty, top, bottom, and invalid values. With `httptest.Server`, assert `POST /nodes/<escaped-id>/mirror`, JSON `parent_id`, omitted/default position, explicit position, response decoding, and preservation of actual non-2xx status/body errors.
+
+- [ ] **Step 2: Run mirror client tests and verify failure**
+
+Run: `go test ./pkg/workflowy -run 'TestMirrorNode' -count=1`
+
+Expected: FAIL because mirror request/response and method are undefined.
+
+- [ ] **Step 3: Implement the request, response, and endpoint**
+
+```go
+type MirrorNodeRequest struct {
+	ParentID string  `json:"parent_id"`
+	Position *string `json:"position,omitempty"`
+}
+
+type MirrorNodeResponse struct {
+	ItemID   string `json:"item_id"`
+	OriginID string `json:"origin_id"`
+}
+```
+
+Implement `SetPosition` via `ValidatePosition` and `WorkflowyClient.MirrorNode` via `wc.Do`. Do not inspect deployment or replace an API error with a locally invented 404.
+
+- [ ] **Step 4: Extend the client interface and update test clients**
+
+Add `MirrorNode` to `workflowy.Client`. Add explicit fake implementations to every listed test client; recording clients should retain the requested source ID and body for later CLI/MCP assertions.
+
+- [ ] **Step 5: Run all unit tests**
+
+Run: `just test`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the client operation**
+
+```bash
+git add pkg/workflowy/mirror_node.go pkg/workflowy/mirror_node_test.go pkg/workflowy/interfaces.go cmd/workflowy/backup_api_test.go cmd/workflowy/client_test.go cmd/workflowy/count_report_test.go pkg/mcp/api_selection_test.go pkg/mcp/tools_test.go
+git commit -m "feat: add Workflowy mirror client operation"
+```
+
+### Task 8: Add the CLI mirror command and effective-destination validation
+
+**Files:**
+- Create: `cmd/workflowy/mirror.go`
+- Create: `cmd/workflowy/mirror_test.go`
+- Create: `pkg/workflowy/mirror_mutation.go`
+- Create: `pkg/workflowy/mirror_mutation_test.go`
+- Modify: `cmd/workflowy/commands.go`
+- Modify: `cmd/workflowy/flags.go`
+- Modify: `cmd/workflowy/invocation.go`
+- Modify: `cmd/workflowy/read_guard.go`
+- Modify: `cmd/workflowy/write_guard.go`
+
+- [ ] **Step 1: Write CLI contract tests**
+
+Assert command name, two required positional arguments, `position`, `method`, `backup-file`, `api`, and credential flags. Cover missing source/parent, `None` destination, full ID, unique short ID, Workflowy URL, target key with API validation, top/bottom, invalid position, text output containing both IDs, and unchanged JSON response fields.
+
+- [ ] **Step 2: Run command tests and verify failure**
+
+Run: `go test ./cmd/workflowy -run 'TestMirrorCommand' -count=1`
+
+Expected: FAIL because `getMirrorCommand` does not exist.
+
+- [ ] **Step 3: Write failing mirror-mutation resolver tests**
+
+In `pkg/workflowy/mirror_mutation_test.go`, write table-driven tests for ordinary nodes, source mirror, parent mirror, missing source, missing parent, missing referenced origin, null/malformed origin, restricted unresolved destination, proven conflict, and unprovable conflict. Assert the complete rich result or a contextual `Cannot ...` error, never a bare boolean.
+
+- [ ] **Step 4: Run resolver tests and verify failure**
+
+Run: `go test ./pkg/workflowy -run TestResolveMirrorMutation -count=1`
+
+Expected: FAIL because the resolver and result type do not exist.
+
+- [ ] **Step 5: Implement the resolver and validation-source helper**
+
+Add one invocation helper that loads the selected validation tree once: backup for `method=backup`, selected deployment export for `get`, `export`, or auto. Resolve full/short/URL inputs against that tree. Use the selected API resolver for target keys only with API-backed validation; reject target keys contextually when backup is the selected validation source. Keep this source tree separate from `ResolvedTree`.
+
+Add a pure shared domain resolver in `pkg/workflowy/mirror_mutation.go`:
+
+```go
+type MirrorMutationResolution struct {
+	RequestedSourceID      string
+	RequestedParentID      string
+	EffectiveSourceID      string
+	EffectiveDestinationID string
+	EffectiveSourceKnown      bool
+	EffectiveDestinationKnown bool
+}
+
+func ResolveMirrorMutation(
+	items []*Item,
+	sourceID, parentID, sourceLabel string,
+	requireEffectiveDestination bool,
+) (MirrorMutationResolution, error)
+```
+
+The resolver indexes the supplied validation tree. Missing requested source or parent always fails with `Cannot ...` plus the missing ID and source label. For an ordinary node, the effective ID is its requested ID and the corresponding `Effective...Known` field is true. For a mirror whose non-empty origin exists in the index, the effective ID is that origin and is known. For null, malformed, or referenced-but-absent origins, the effective ID remains the requested ID and the corresponding known field is false; this fails contextually only when `requireEffectiveDestination` is true.
+
+If both effective IDs are known and equal, fail before the API call with source, requested parent, effective ID, and source label. If either side is unknown, do not invent a conflict; let the selected API decide. The request path always uses `RequestedSourceID` and the body always uses `RequestedParentID`, even when validation uses `EffectiveDestinationID`.
+
+- [ ] **Step 6: Write access, load-count, and deployment-routing tests**
+
+Cover missing source, missing requested parent, source outside `read-root-id`, ordinary destination outside `write-root-id`, a parent mirror inside the write root whose origin is outside, a parent mirror outside whose origin is inside, referenced effective origin absent with and without restriction, null/malformed destination origin, source-origin destination conflict when provable, unprovable conflict delegated to the API, `--api=production`, `--api=beta`, and actual API errors from either deployment. In parent-mirror cases, assert `MirrorNode` receives requested source and parent IDs, never effective validation IDs. Use a counting provider to assert each command loads exactly one validation snapshot even without access restrictions: backup for `method=backup`, and one selected-deployment export for get/export/auto. Assert every local error starts with `Cannot` and includes relevant IDs/source label; assert no local beta gate and no hardcoded status.
+
+- [ ] **Step 7: Run access tests and verify failure**
+
+Run: `go test ./cmd/workflowy -run 'TestMirrorCommand.*(Access|Destination|API|Error)' -count=1`
+
+Expected: FAIL until validation and routing are implemented.
+
+- [ ] **Step 8: Implement `getMirrorCommand`**
+
+Register the command in `getCommands`. Resolve source and parent to full IDs, reject root, call `workflowy.ResolveMirrorMutation` on the invocation's single validation snapshot, validate requested source against the source-tree read scope and known effective destination against the source-tree write scope, then call `MirrorNode`. Wrap position validation with the supplied position and operation. Always wrap API failures with source ID, requested parent, effective destination, and selected deployment:
+
+```go
+return fmt.Errorf(
+	"Cannot mirror Workflowy node %q into requested parent %q with effective destination %q using Workflowy API %q: %w",
+	resolution.RequestedSourceID,
+	resolution.RequestedParentID,
+	resolution.EffectiveDestinationID,
+	deployment,
+	err,
+)
+```
+
+Use early returns and keep the command in `mirror.go`, not the already-large `commands.go`.
+
+- [ ] **Step 9: Run CLI tests**
+
+Run: `go test ./cmd/workflowy -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit the CLI command**
+
+```bash
+git add cmd/workflowy/mirror.go cmd/workflowy/mirror_test.go pkg/workflowy/mirror_mutation.go pkg/workflowy/mirror_mutation_test.go cmd/workflowy/commands.go cmd/workflowy/flags.go cmd/workflowy/invocation.go cmd/workflowy/read_guard.go cmd/workflowy/write_guard.go
+git commit -m "feat: create Workflowy mirrors from CLI"
+```
+
+### Task 9: Add the MCP mirror tool with matching options
+
+**Files:**
+- Create: `pkg/mcp/mirror_tool.go`
+- Create: `pkg/mcp/mirror_tool_test.go`
+- Modify: `pkg/mcp/tools.go`
+- Modify: `pkg/mcp/tools_test.go`
+- Modify: `pkg/mcp/server.go`
+- Modify: `pkg/mcp/server_test.go`
+- Modify: `pkg/mcp/api_selection_test.go`
+
+- [ ] **Step 1: Write exact schema and expose-list tests**
+
+Assert `ToolMirror == "workflowy_mirror"`; required string `id` and `parent_id`; optional enum `position` top/bottom; optional enum `method` get/export/backup; centralized enum `api` production/beta. Assert `mirror`, `workflowy_mirror`, `write`, and `all` expose it exactly once, while `read` does not.
+
+- [ ] **Step 2: Run schema tests and verify failure**
+
+Run: `go test ./pkg/mcp -run 'Test.*Mirror.*(Schema|Expose)' -count=1`
+
+Expected: FAIL because the tool is not registered.
+
+- [ ] **Step 3: Register the schema through existing dispatch**
+
+Add the constant/factory/network-tool entries in `tools.go` and group/alias entries in `server.go`. Implement `func (b ToolBuilder) buildMirrorTool() mcpserver.ServerTool` in `mirror_tool.go` with the exact schema and a temporary handler that returns a contextual not-implemented tool error. Let `selectAPIHandler` add and process `api`; do not add a second selector inside the handler. Do not implement validation, loading, or mutation behavior in this step.
+
+- [ ] **Step 4: Write handler, access, error, and concurrency tests**
+
+Mirror the CLI cases for ID resolution, missing source, missing requested parent, missing referenced effective origin under restriction, source read restriction, effective destination write restriction, position, root rejection, backup validation, mirror-of-mirror response, proven and unprovable conflict, production/beta dispatch, actual API error preservation, and simultaneous calls using different APIs/methods. In parent-mirror cases, assert the client receives requested IDs rather than effective validation IDs. Assert local errors start with `Cannot` and contain source, requested-parent, effective-destination, deployment, and source-label context. Assert the JSON response contains `item_id` and the true `origin_id` returned by Workflowy.
+
+Use counting clients/providers to prove one selected validation snapshot per call: `method=backup` reuses the prepared backup tree; `get`, `export`, and auto each use one export from the selected deployment for ID resolution, access checks, `ResolveMirrorMutation`, and conflict detection.
+
+- [ ] **Step 5: Run behavior tests and verify failure**
+
+Run: `go test ./pkg/mcp -run 'TestMirrorTool' -count=1`
+
+Expected: FAIL until the handler uses the source-tree validation path and client operation.
+
+- [ ] **Step 6: Implement the handler and mutation-specific snapshot preparation**
+
+Make `prepareInvocation` load a validation snapshot for `workflowy_mirror` on every call, even when no read/write restriction is active: backup for `method=backup`, and one selected-deployment export for get/export/auto. Use `workflowy.ResolveMirrorMutation` with that snapshot and reuse source-tree access validators; do not copy metadata parsing into MCP. Validate the requested source ID and the known effective destination, but send the requested source/parent IDs to `MirrorNode`. Wrap position errors with operation and supplied value. Return `mcptypes.NewToolResultJSON(response)` on success. Wrap API failures with the same exact source, requested-parent, effective-destination, and deployment form used by CLI before converting them to a tool error.
+
+- [ ] **Step 7: Run MCP tests with races**
+
+Run: `go test -race ./pkg/mcp -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit MCP mirror creation**
+
+```bash
+git add pkg/mcp/mirror_tool.go pkg/mcp/mirror_tool_test.go pkg/mcp/tools.go pkg/mcp/tools_test.go pkg/mcp/server.go pkg/mcp/server_test.go pkg/mcp/api_selection_test.go
+git commit -m "feat: create Workflowy mirrors from MCP"
+```
+
+## Chunk 4: Integration, documentation, and final validation
+
+### Task 10: Add read-only and destructive mirror integration coverage
+
+**Files:**
+- Modify: `test/api_read.bats`
+- Modify: `test/api_write.bats`
+- Modify: `test/test_helper.bash`
+- Modify: `justfile`
+
+- [ ] **Step 1: Add fixture guards before test bodies**
+
+Add helpers that skip read tests unless `TEST_MIRROR_ID` is set, and skip write tests unless both `TEST_MIRROR_SOURCE_ID` and `TEST_MIRROR_PARENT_ID` are set. Accept optional `TEST_MIRROR_EXPECTED_ORIGIN_ID` for a source fixture that is itself a mirror. Validate configured IDs are neither empty nor `None`; never infer a writable node from account data. Require `TEST_MIRROR_SOURCE_ID` and, when supplied, `TEST_MIRROR_EXPECTED_ORIGIN_ID` to be full UUIDs because the test compares them directly with the API's full `origin_id` response.
+
+- [ ] **Step 2: Align just targets with read/write separation**
+
+Change `test-integration` to run both `test/reports.bats` and `test/api_read.bats`. Retain `test-integration-write` exclusively for `test/api_write.bats`; do not add write tests to `test-all`. Extend the destructive-target warning to name `TEST_MIRROR_SOURCE_ID` and `TEST_MIRROR_PARENT_ID` alongside `TEST_PARENT_ID`.
+
+- [ ] **Step 3: Add beta read tests**
+
+In `api_read.bats`, compare descendant ID sets from `get --api=beta --method=get` and `get --api=beta --method=export` for `TEST_MIRROR_ID`. Add a third assertion that `--resolve-mirrors=false --depth=2 --format=json` returns the requested mirror with no `children`.
+
+- [ ] **Step 4: Run the read-only target**
+
+Run: `just test-integration`
+
+Expected: PASS, with mirror tests skipped when `TEST_MIRROR_ID` is absent.
+
+- [ ] **Step 5: Add the create-and-clean-up write test**
+
+In `api_write.bats`, call `workflowy mirror "$TEST_MIRROR_SOURCE_ID" "$TEST_MIRROR_PARENT_ID" --api=beta --format=json`, capture `item_id` and `origin_id`, and immediately register the new ID in a beta-specific cleanup list before later assertions can fail. Teardown calls ordinary `workflowy delete "$item_id" --api=beta`. Assert both IDs are non-empty. For an ordinary source, assert `origin_id` equals the source ID; for a mirror source, require `TEST_MIRROR_EXPECTED_ORIGIN_ID` and assert the returned value equals it.
+
+- [ ] **Step 6: Run Bats syntax and unit tests**
+
+Run: `bash -n test/test_helper.bash && bats --count test/api_write.bats && bats --formatter tap test/api_read.bats`
+
+Expected: helper syntax passes, the destructive file's tests are discovered without executing them, and read live-fixture tests either pass or report skips. Then run `just test` and expect PASS.
+
+- [ ] **Step 7: Commit integration coverage**
+
+```bash
+git add test/api_read.bats test/api_write.bats test/test_helper.bash justfile
+git commit -m "test: cover Workflowy mirror integration"
+```
+
+### Task 11: Document all interfaces and release behavior
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/CLI.md`
+- Modify: `docs/MCP.md`
+- Modify: `docs/architecture.md`
+- Modify: `CHANGELOG.md`
+- Create: `docs/blog/2026-08-04-workflowy-mirror-support.md`
+
+- [ ] **Step 1: Update CLI and README examples**
+
+Document `--resolve-mirrors=true|false` on get/list/search, `--search-mirrors`, the conflict, occurrence preference, `workflowy mirror <id> <parent-id>`, `--method`, `--position`, and shared `--api`. Include one beta example and one production example that explains the selected API's actual error is authoritative.
+
+- [ ] **Step 2: Update MCP reference and inventory**
+
+Document `resolve_mirrors` on get/list/search, `search_mirrors` on search, `workflowy_mirror` schema, `mirror` expose alias, write/all membership, warning content blocks, and ordinary delete as mirror removal. Ensure all schema names use snake_case.
+
+- [ ] **Step 3: Synchronize architecture, observability, and changelog**
+
+Verify `docs/architecture.md` describes the resolved tree as an on-demand view, target-directed fetch, streaming search, path-local cycles, and the inherent time cost of dense mirror graphs. Document debug index, traversal, retention, path-depth, elapsed-time, and Go heap/GC attributes in CLI and MCP troubleshooting sections. If implementation diverges materially, fix the implementation; if that is not possible, stop and request design approval instead of redefining the architecture in documentation. Add the new topmost `## [0.10.0] - Mirror Support` CHANGELOG entry covering mirror reads, search policy, mirror creation, defaults, observability, and no production gate.
+
+- [ ] **Step 4: Write the feature release post**
+
+Create `docs/blog/2026-08-04-workflowy-mirror-support.md` with motivation, source vs resolved trees, examples for all interfaces, safety/access behavior, observability warnings, beta availability today, and the metadata-driven production path. Do not claim undocumented HTTP statuses.
+
+- [ ] **Step 5: Check terminology and links**
+
+Run: `rg -n -i 'source tree|resolved tree' README.md docs CHANGELOG.md`
+
+Expected: user-facing design documentation consistently uses the approved source-tree and resolved-tree terms. Then run this negative check for the three rejected terms:
+
+```bash
+for rejected_term in "canon""ical" "logi""cal" "projec""ted"; do
+  if rg -n -i "$rejected_term" README.md docs CHANGELOG.md; then
+    exit 1
+  fi
+done
+git diff --check
+```
+
+Expected: no matches and no diff errors.
+
+- [ ] **Step 6: Commit documentation**
+
+```bash
+git add README.md docs/CLI.md docs/MCP.md docs/architecture.md CHANGELOG.md docs/blog/2026-08-04-workflowy-mirror-support.md
+git commit -m "docs: explain Workflowy mirror support"
+```
+
+### Task 12: Simplify, review, and verify the complete feature
+
+**Files:**
+- Modify: only files identified by the simplification and review findings
+
+- [ ] **Step 1: Format and run the full unit suite**
+
+Run: `git diff --name-only --diff-filter=ACMR 6aa849e -- '*.go' | xargs gofmt -w && just test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full race suite**
+
+Run: `go test -race ./... -count=1`
+
+Expected: PASS with no races.
+
+- [ ] **Step 3: Run read-only integration tests**
+
+Run: `just test-integration`
+
+Expected: PASS; explicitly configured live mirror cases may run, otherwise skip. Do not run `just test-integration-write` without the dedicated user-provided fixtures.
+
+- [ ] **Step 4: Run @code-simplifier on the feature diff**
+
+Apply the code-simplifier skill to the complete feature working-tree diff from `6aa849e`, preserving behavior. Focus on duplicated mirror option plumbing, metadata parsing, occurrence selection, validation-tree loading, and warning-result construction. Re-run `just test` and `go test -race ./... -count=1` after any edit.
+
+- [ ] **Step 5: Run @requesting-code-review against the design spec**
+
+Review `git diff 6aa849e` against `docs/2026-08-04-mirror-support-design.md` and `docs/architecture.md`; this form includes committed feature work and current simplifier edits. Resolve all blocking Standards and Spec findings, then re-run focused tests for every touched package.
+
+- [ ] **Step 6: Verify repository state and coverage-sensitive paths**
+
+Run:
+
+```bash
+go test -race ./... -count=1
+go test ./... -coverprofile=/tmp/workflowy-mirror-cover.out
+go tool cover -func=/tmp/workflowy-mirror-cover.out | tail -1 | tee /tmp/workflowy-mirror-final-coverage.txt
+baseline_coverage=$(awk '/^total:/{gsub("%", "", $3); print $3}' /tmp/workflowy-mirror-baseline-coverage.txt)
+final_coverage=$(awk '/^total:/{gsub("%", "", $3); print $3}' /tmp/workflowy-mirror-final-coverage.txt)
+test -n "$baseline_coverage"
+test -n "$final_coverage"
+awk -v baseline="$baseline_coverage" -v final="$final_coverage" 'BEGIN { if (final + 0 < baseline + 0) exit 1 }'
+git diff --check
+git status --short
+```
+
+Expected: race and coverage tests pass; the command exits nonzero if total coverage decreases; diff check is clean; only intentional feature files appear before the final cleanup commit.
+
+- [ ] **Step 7: Commit every remaining tracked feature edit**
+
+If formatting, simplification, or review left tracked working-tree changes, stage exactly the paths reported by the reviewed diff and commit them. Do not create new files in this final cleanup step.
+
+```bash
+if ! git diff --quiet; then
+  git diff --name-only --diff-filter=ACMRD -z | xargs -0 git add --
+  git commit -m "refactor: simplify Workflowy mirror support"
+fi
+```
+
+If no tracked files changed, record that no final fixup commit was necessary in the execution handoff.
+
+- [ ] **Step 8: Run final range and repository checks**
+
+Run: `git diff --check 6aa849e..HEAD && git status --short`
+
+Expected: the committed feature range has no whitespace errors and the working tree is clean.

--- a/docs/superpowers/plans/2026-08-03-api-selection.md
+++ b/docs/superpowers/plans/2026-08-03-api-selection.md
@@ -1,0 +1,431 @@
+# Workflowy API Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let CLI and MCP users select Workflowy's production or beta deployment while preserving production defaults, offline backup behavior, and deployment-isolated export caches.
+
+**Architecture:** Introduce a validated `APIDeployment` domain value in `pkg/workflowy`, construct Workflowy clients from that value, and bind each client to an explicit export-cache path. CLI commands construct one selected client; MCP retains both clients and selects an immutable `ToolBuilder` copy per invocation before resolving restriction roots against the effective validation source.
+
+**Tech Stack:** Go 1.24, urfave/cli v3, mcp-go v0.43, `log/slog`, testify, Bats, Markdown, `just`
+
+---
+
+## Chunk 1: Deployment domain, cache isolation, and CLI selection
+
+### Task 1: Define and validate the API deployment domain
+
+**Files:**
+- Create: `pkg/workflowy/api_deployment.go`
+- Create: `pkg/workflowy/api_deployment_test.go`
+
+- [ ] **Step 1: Write failing deployment tests**
+
+Cover these cases in `TestParseAPIDeployment`:
+
+```go
+tests := []struct {
+	raw      string
+	want     APIDeployment
+	wantErr  string
+}{
+	{raw: "", want: ProductionAPI},
+	{raw: "production", want: ProductionAPI},
+	{raw: "beta", want: BetaAPI},
+	{raw: "prod", wantErr: `Cannot select Workflowy API "prod": expected "production" or "beta"`},
+}
+```
+
+Also assert that production and beta map to `https://workflowy.com/api/v1` and `https://beta.workflowy.com/api/v1`, and to distinct production-compatible cache filenames.
+
+- [ ] **Step 2: Run RED**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./pkg/workflowy -run 'TestParseAPIDeployment|TestAPIDeployment' -count=1`
+
+Expected: FAIL because `APIDeployment`, its constants, parser, and mappings do not exist.
+
+- [ ] **Step 3: Implement the closed deployment value**
+
+Create:
+
+```go
+type APIDeployment string
+
+const (
+	ProductionAPI APIDeployment = "production"
+	BetaAPI       APIDeployment = "beta"
+)
+
+func ParseAPIDeployment(raw string) (APIDeployment, error)
+func (deployment APIDeployment) BaseURL() (string, error)
+func (deployment APIDeployment) exportCacheFile() (string, error)
+```
+
+Parsing defaults an empty string to production. All invalid paths return the contextual `Cannot select Workflowy API ...` error. The production cache filename stays `.workflowy/export-cache.json`; beta uses `.workflowy/export-cache-beta.json`.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the Step 2 command again.
+
+Expected: PASS.
+
+### Task 2: Make export-cache paths explicit and deployment-bound
+
+**Files:**
+- Create: `pkg/cache/export_test.go`
+- Modify: `pkg/cache/export.go`
+- Modify: `pkg/workflowy/workflowy.go`
+- Modify: `pkg/workflowy/workflowy_test.go`
+- Modify: `cmd/workflowy/commands.go`
+- Modify: `pkg/mcp/server.go`
+
+- [ ] **Step 1: Write failing cache isolation tests**
+
+In `pkg/cache/export_test.go`, create two temporary paths, write different payloads through `WriteExportCache(path, payload)`, read them through `ReadExportCache(path)`, and assert neither path returns the other's data.
+
+In `pkg/workflowy/workflowy_test.go`, set `HOME` to `t.TempDir()`, construct production and beta clients, and assert their internal `exportCachePath` fields are:
+
+```text
+<HOME>/.workflowy/export-cache.json
+<HOME>/.workflowy/export-cache-beta.json
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./pkg/cache ./pkg/workflowy -run 'TestExportCacheIsolation|TestNewWorkflowyClientForAPI' -count=1`
+
+Expected: FAIL because cache functions do not accept paths and the API-aware constructor does not exist.
+
+- [ ] **Step 3: Implement explicit cache paths**
+
+Change the cache interface to:
+
+```go
+func GetCachePath(relativePath string) (string, error)
+func ReadExportCache(cachePath string) (*ExportCache, error)
+func WriteExportCache(cachePath string, data any) error
+```
+
+Add `exportCachePath string` to `WorkflowyClient` and deliberately replace the current no-error constructor with:
+
+```go
+func NewWorkflowyClient(deployment APIDeployment, opts ...client.Option) (*WorkflowyClient, error)
+```
+
+This is an intentional source-level API change: the repo has only the CLI and MCP constructor call sites, and preserving the no-error wrapper would either hide or panic on deployment/cache-path failures. In this same task, update both call sites to pass `ProductionAPI` explicitly and propagate constructor errors so the intermediate commit remains buildable; later tasks replace that fixed selection with user input. The constructor validates deployment mappings, resolves its cache path, constructs the generic client, and logs the selected deployment at debug level. `ExportNodesWithCache` passes the instance path to every cache read and write, including stale fallback and rate-limit checks.
+
+- [ ] **Step 4: Run GREEN and verify the constructor migration repo-wide**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./... -count=1`
+
+Expected: PASS, including the CLI and MCP call sites changed for the new constructor signature.
+
+- [ ] **Step 5: Commit the domain and cache slice**
+
+```bash
+git add pkg/cache/export.go pkg/cache/export_test.go pkg/workflowy/api_deployment.go pkg/workflowy/api_deployment_test.go pkg/workflowy/workflowy.go pkg/workflowy/workflowy_test.go cmd/workflowy/commands.go pkg/mcp/server.go
+git commit -m "feat: add Workflowy API deployments"
+```
+
+### Task 3: Expose API selection across CLI commands
+
+**Files:**
+- Modify: `cmd/workflowy/flags.go`
+- Modify: `cmd/workflowy/flags_test.go`
+- Modify: `cmd/workflowy/commands.go`
+- Create: `cmd/workflowy/client_test.go`
+- Create: `cmd/workflowy/report_api_test.go`
+
+- [ ] **Step 1: Write failing flag-parity tests**
+
+Construct the real command tree and iterate the exact required command paths for this slice: get, list, create, update, move, delete, complete, uncomplete, targets, search, replace, transform, id, and every report subcommand. Assert each command exposes a string flag named `api` with default `production`; this specifically covers `move`, which has its own flag list. Assert both `mcp` (deferred to Task 4) and `version` do not yet expose the command-local flag.
+
+- [ ] **Step 2: Write failing client-factory tests**
+
+Define a test factory that records the `workflowy.APIDeployment` passed to it. With `WORKFLOWY_API_KEY` set, verify the factory-backed client provider selects beta, an empty value selects production, and an invalid value returns the exact contextual error without invoking the factory.
+
+Add `getGetCommandWithClientProvider(provider)` as the same narrow command-construction seam already used by count reports. Execute the real get command with `--api=beta --method=get --depth=0` and assert the provider/fake client sees beta. Execute the optional-client get path with credentials absent and `--api=staging`; assert API validation fails before credential resolution and backup fallback, with zero factory calls.
+
+Using the existing `getCountReportCommandWithDeps` seam and a factory-backed provider, execute `report count --method=backup --backup-file=<fixture> --upload --api=beta`. Assert the report tree is read from the fixture while its create/upload calls go only to the beta fake client. This proves `api` remains active when the read method is offline.
+
+- [ ] **Step 3: Run RED**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./cmd/workflowy -run 'Test.*API.*Flag|Test.*Client.*API|TestGetCommand.*API|TestCountReportBackupUploadUsesSelectedAPI' -count=1`
+
+Expected: FAIL because the flag and factory seam do not exist.
+
+- [ ] **Step 4: Implement the shared CLI flag**
+
+Add:
+
+```go
+func getAPIFlag() *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:  "api",
+		Value: string(workflowy.ProductionAPI),
+		Usage: "Workflowy API deployment: production or beta",
+	}
+}
+```
+
+Include it beside `api-key-file` in method, write, mirror-report, targets, ID, and the dedicated `move` flag list. Do not add it to MCP yet (Task 4 wires the flag and server config atomically), and do not add it to `version`.
+
+- [ ] **Step 5: Implement the explicit CLI client-factory seam**
+
+Introduce an internal factory function type mapping a validated deployment and client options to `workflowy.Client`. Make the factory-backed provider parse `cmd.String("api")` before resolving the API key, then call `NewWorkflowyClient`. Update `withClient` and `withOptionalClient` to use the provider. The optional provider may fall back to backup only after a valid deployment has been established and credential resolution fails; invalid deployments must fail first. Use `getGetCommandWithClientProvider` for the command-level test without introducing a broader dependency container.
+
+- [ ] **Step 6: Run GREEN and all CLI tests**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./cmd/workflowy -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the CLI slice**
+
+```bash
+git add cmd/workflowy/flags.go cmd/workflowy/flags_test.go cmd/workflowy/commands.go cmd/workflowy/client_test.go cmd/workflowy/report_api_test.go
+git commit -m "feat: select Workflowy API from CLI"
+```
+
+---
+
+## Chunk 2: MCP selection, offline validation, and interface documentation
+
+### Task 4: Select a deployment per MCP invocation
+
+**Files:**
+- Modify: `cmd/workflowy/commands.go`
+- Modify: `pkg/mcp/server.go`
+- Create: `pkg/mcp/server_test.go`
+- Modify: `pkg/mcp/tools.go`
+- Create: `pkg/mcp/api_selection_test.go`
+
+- [ ] **Step 1: Write failing MCP CLI and startup tests**
+
+Assert the real `workflowy mcp` command exposes `--api` with default `production` and passes it into `mcp.Config.API`.
+
+Introduce injectable MCP credential-resolver and client-factory seams and test startup construction directly: invalid server API fails before credential resolution and calls both seams zero times; a valid API calls the credential resolver exactly once, supplies the returned bearer option to production and beta constructors, constructs both without making a network request, and records the configured default. Apply the option inside each recording factory call and inspect the resulting Authorization header rather than comparing option closures.
+
+- [ ] **Step 2: Write failing exact tool-schema and dispatch tests**
+
+Define one exact `networkToolNames` set using these 17 constants: `ToolGet`, `ToolList`, `ToolSearch`, `ToolTargets`, `ToolID`, `ToolCreate`, `ToolUpdate`, `ToolMove`, `ToolDelete`, `ToolComplete`, `ToolUncomplete`, `ToolReportCount`, `ToolReportChildren`, `ToolReportCreated`, `ToolReportModified`, `ToolReplace`, and `ToolTransform`. Build every MCP tool and assert each member has an `api` string enum containing exactly `production` and `beta`, and that every member's handler is routed through the deployment-selection wrapper. Assert `ToolReportMirrors` has neither the property nor the network wrapper.
+
+Invoke `workflowy_get` with `method=get`, `depth=0`, and a root ID. Assert explicit `api=beta` calls only beta, omission uses the configured server default, and `api=staging` returns an MCP tool error without calling either client.
+
+- [ ] **Step 3: Run RED**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./cmd/workflowy ./pkg/mcp -run 'Test.*MCP.*API|Test.*Tool.*API|Test.*API.*Dispatch' -count=1`
+
+Expected: FAIL because MCP has no flag/config/factory and ToolBuilder accepts only one client.
+
+- [ ] **Step 4: Construct both MCP clients at startup**
+
+Add `API string` to `mcp.Config`, add the CLI flag, and populate the field. Factor server setup so tests can inject a credential resolver plus a constructor mapping `APIDeployment` and client options to `workflowy.Client`. Parse the server default before calling the resolver, call the resolver once, then construct production and beta clients from that same option. Retain raw read/write root values and remove startup network resolution. Construction itself performs no HTTP operation.
+
+- [ ] **Step 5: Centralize schema decoration and immutable handler wrapping**
+
+Refactor the tool factory table to accept a `ToolBuilder` value. In `BuildTools`, use the exact `networkToolNames` set as the single authority: construct the base tool, add the shared `api` schema option, and replace its handler with a wrapper that parses per-call API, selects the matching client, logs the effective deployment, prepares an immutable invocation-specific builder copy, reconstructs the selected tool from that copy, and calls its handler. Never mutate a captured builder.
+
+Build the mirror tool separately without the API option, but wrap it with a dedicated forced-backup invocation wrapper. That wrapper loads the configured/latest backup once, resolves roots locally, and passes the prepared builder to the mirror handler; it never selects or calls an API client.
+
+This centralized loop must make it impossible to add schema without runtime dispatch or vice versa; its test checks the exact set against all constructed tools.
+
+- [ ] **Step 6: Run GREEN and race-sensitive MCP tests**
+
+Run:
+
+```bash
+GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./cmd/workflowy ./pkg/mcp -count=1
+GOCACHE=/private/tmp/workflowy-api-selection-cache go test -race ./pkg/mcp -count=1
+```
+
+Expected: PASS with no race report.
+
+### Task 5: Make backup validation completely offline and deployment-relative
+
+**Files:**
+- Create: `pkg/workflowy/resolve.go`
+- Create: `pkg/workflowy/resolve_test.go`
+- Modify: `pkg/mcp/tools.go`
+- Create: `pkg/mcp/tools_test.go`
+- Modify: `pkg/mcp/api_selection_test.go`
+
+- [ ] **Step 1: Write failing local-ID resolver tests**
+
+Add tests for a tree-only resolver that verifies a full UUID, resolves one unique 12-character suffix, and returns contextual `Cannot resolve Workflowy node ...` errors for missing or ambiguous IDs. The resolver accepts only full/short IDs; target-key policy remains in MCP where the validation source is known.
+
+- [ ] **Step 2: Write failing invocation-backup tests**
+
+Inject a backup provider with call counters, an explicit backup filename, a known full UUID, and a second node resolvable by its 12-character suffix. Invoke tools using backup method and assert:
+
+- the backup is loaded exactly once per invocation and stored as `invocationTree` with source label equal to the configured filename (or exactly `latest Workflowy backup` when none is configured);
+- read/write roots and the exact request ID fields resolve from that same tree: `id` for get/list/search/id/update/move/delete/complete/uncomplete/all four network reports/transform; `parent_id` for create/move/replace; and `to_ancestor` for get before slicing the ancestor chain;
+- a complete read-only backup invocation makes zero client calls;
+- writes validate locally but send the mutation through the selected deployment client;
+- target-key root `inbox` fails without network with `Cannot resolve read root "inbox" from backup "<label>": target keys require an API; configure read_root_id with a full or short node ID`.
+
+- [ ] **Step 3: Write failing deployment-relative network tests**
+
+Configure different node/root lookup results on production and beta fakes. Assert a beta override resolves target keys, short request IDs, restriction roots, and validation only through beta. Assert a beta root failure names the raw root and beta deployment, while a later production invocation succeeds. Assert a write whose validation method is backup still mutates only the selected beta client.
+
+- [ ] **Step 4: Write failing mirror-report offline/scope tests**
+
+Assert the mirror report uses the configured backup provider/file, loads once, makes zero client calls, and scopes results to the resolved read root. Cover full and short roots plus the target-key offline error. This replaces the current direct latest-backup read and prevents the report from bypassing configured roots.
+
+- [ ] **Step 5: Run RED**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./pkg/workflowy ./pkg/mcp -run 'Test.*Resolve.*Tree|Test.*Backup|Test.*RestrictionRoot|Test.*Mirror.*Root' -count=1`
+
+Expected: FAIL because handlers still resolve IDs through the API and mirror reporting bypasses invocation state.
+
+- [ ] **Step 6: Implement one invocation validation source**
+
+Add the tree-only full/short resolver in `pkg/workflowy`. Extend the invocation builder with `invocationTree`, `invocationSourceLabel`, and resolved roots. At wrapper entry, derive the effective method and:
+
+- for backup, load the configured file or latest backup exactly once, assign the exact source label, and resolve roots locally;
+- for get/export/auto, resolve roots with the selected client and that deployment's export tree/cache.
+
+Add builder methods for resolving the exact handler fields listed in Step 2. Replace every direct handler call to `workflowy.ResolveNodeID` and `ResolveNodeIDToUUID`, and resolve get's `to_ancestor` before ancestor slicing, so backup mode cannot accidentally perform HTTP. Target keys in backup return the contextual offline error; network target/short resolution uses only the selected client. Do not cache invocation state across calls.
+
+Make `loadTree`, `loadTreeWithRefresh`, `loadBackupTree`, ancestor fetch, restriction validation, report loading, and mirror loading return/reuse the stored `invocationTree` whenever it is present. No code beneath either invocation wrapper may reread the backup provider.
+
+Update mirror reporting to use the prepared backup invocation tree and restrict it to the resolved read-root subtree before collecting mirrors. It remains API-argument-free and offline.
+
+- [ ] **Step 7: Run GREEN and all MCP tests**
+
+Run:
+
+```bash
+GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./pkg/workflowy ./pkg/mcp -count=1
+GOCACHE=/private/tmp/workflowy-api-selection-cache go test -race ./pkg/mcp -count=1
+```
+
+Expected: PASS with no network calls in backup assertions and no race report.
+
+- [ ] **Step 8: Commit the MCP slice**
+
+```bash
+git add cmd/workflowy/commands.go pkg/workflowy/resolve.go pkg/workflowy/resolve_test.go pkg/mcp/server.go pkg/mcp/server_test.go pkg/mcp/tools.go pkg/mcp/tools_test.go pkg/mcp/api_selection_test.go
+git commit -m "feat: select Workflowy API per MCP call"
+```
+
+### Task 6: Document both interfaces and add read-only integration coverage
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/CLI.md`
+- Modify: `docs/MCP.md`
+- Modify: `test/api_read.bats`
+
+- [ ] **Step 1: Update the README examples and cache notes**
+
+In `Run Your First Command`, add these examples:
+
+```bash
+workflowy get --depth=0                         # production (default)
+workflowy get --depth=0 --api=beta             # beta deployment
+```
+
+Immediately before `Data Access Methods`, add `## API Deployment` explaining that `--api` chooses production/beta while `--method` chooses get/export/backup transport. State that beta exposes mirror metadata such as `data.mirror.origin_id` that production does not currently expose, without claiming normalization. In `Data Access Methods`, list production cache `~/.workflowy/export-cache.json` and beta cache `~/.workflowy/export-cache-beta.json`.
+
+- [ ] **Step 2: Update the complete CLI reference**
+
+Immediately after `Global Options`, add a separate `API Selection` subsection explaining that `--api <production|beta>` is command-local, defaults to production, rejects other values, and is intentionally absent from `version`; do not put it in the global-options table or imply `workflowy --api=beta get` syntax. In each existing command `Options` table for get, list, create, update, move, delete, complete, uncomplete, targets, search, replace, and transform, add the option. Create missing `workflowy id` and `workflowy mcp` command-reference sections (and Table of Contents entries) with their usage/options, including `--api`. Add the same row to `Report Commands`' shared options table so count/children/created/modified/mirrors inherit it. Under `Data Access Methods`, add an `API Deployment vs. Access Method` subsection with:
+
+```bash
+workflowy get --api=beta --method=get --depth=0
+workflowy report count --api=beta --method=backup --upload
+```
+
+Explain that the second reads/validates from backup but uploads through beta, and list the two deployment-specific cache paths.
+
+- [ ] **Step 3: Update the complete MCP reference**
+
+In `Client Configuration`, show `workflowy mcp --api=beta`. In every existing parameter table for the network tools named in Task 4, add optional `api` enum with the production/server default. Create a missing `workflowy_id` subsection and Table of Contents entry documenting its `id` and `api` parameters. Leave the `workflowy_report_mirrors` table unchanged and add a note that it is backup-only and intentionally has no `api`. Insert `## API Deployment` immediately before `Access Method`, documenting precedence `tool api > server --api > production`, API-versus-method semantics, backup full/short ID support and target-key limitation, and the two cache paths. Include this per-call example:
+
+```json
+{"id": "None", "depth": 0, "method": "get", "api": "beta"}
+```
+
+- [ ] **Step 4: Add opt-in read-only integration tests**
+
+Immediately after the existing get tests, add these concrete read-only cases (the file's `setup` already enforces credentials):
+
+```bash
+@test "get root from production API" {
+    require_jq
+    run run_workflowy get --api=production --method=get --depth=0 --format=json --log=error
+    [ "$status" -eq 0 ]
+    assert_valid_json "$output"
+}
+
+@test "get root from beta API" {
+    require_jq
+    run run_workflowy get --api=beta --method=get --depth=0 --format=json --log=error
+    [ "$status" -eq 0 ]
+    assert_valid_json "$output"
+}
+```
+
+- [ ] **Step 5: Run documentation and integration structure checks**
+
+Run:
+
+```bash
+bats --count test/api_read.bats
+git diff --check
+```
+
+Expected: Bats reports the discovered test count and whitespace checks pass. If Workflowy credentials and network access are available, additionally run `just test-integration-api`; otherwise record that the live check was skipped.
+
+- [ ] **Step 6: Commit documentation parity**
+
+```bash
+git add README.md docs/CLI.md docs/MCP.md test/api_read.bats
+git commit -m "docs: describe Workflowy API selection"
+```
+
+### Task 7: Verify and review the complete feature
+
+**Files:**
+- Verify all changed files; commit formatting/review fixes when needed
+
+- [ ] **Step 1: Format before final verification**
+
+Run `gofmt -w` on every changed Go file, inspect `git diff --check`, and commit any formatting changes with the slice they affect (or as a focused follow-up) before claiming a clean implementation.
+
+- [ ] **Step 2: Run unit tests and static analysis**
+
+Run:
+
+```bash
+just test
+go vet ./...
+```
+
+Expected: all packages PASS and vet exits without diagnostics.
+
+- [ ] **Step 3: Run race-sensitive client and MCP tests**
+
+Run: `GOCACHE=/private/tmp/workflowy-api-selection-cache go test -race ./pkg/client ./pkg/workflowy ./pkg/mcp -count=1`
+
+Expected: PASS with no race report.
+
+- [ ] **Step 4: Run focused interface behavior checks**
+
+Run the explicitly created behavior tests:
+
+```bash
+GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./cmd/workflowy -run 'Test.*API.*Flag|Test.*Client.*API|TestGetCommand.*API|TestCountReportBackupUploadUsesSelectedAPI' -count=1
+GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./pkg/cache ./pkg/workflowy -run 'TestExportCacheIsolation|TestNewWorkflowyClientForAPI|TestParseAPIDeployment|Test.*Resolve.*Tree' -count=1
+GOCACHE=/private/tmp/workflowy-api-selection-cache go test ./pkg/mcp -run 'Test.*MCP.*API|Test.*Tool.*API|Test.*API.*Dispatch|Test.*Backup|Test.*RestrictionRoot|Test.*Mirror.*Root' -count=1
+```
+
+Expected: the CLI suite includes move and every report in its exact flag-parity table plus the backup-read/beta-upload behavior; MCP covers schema/runtime parity, server/per-call precedence, offline IDs/roots, and mirror scoping; cache tests prove deployment isolation.
+
+- [ ] **Step 5: Inspect final scope**
+
+Run `git status --short` and `git log -12 --oneline`. Expected: only the pre-existing `.gocache/` and `scripts/` remain untracked; all API-selection source, tests, and documentation are committed on `feat/api-selection`.
+
+- [ ] **Step 6: Request completion review**
+
+Use the requesting-code-review workflow against the implementation range and `docs/superpowers/specs/2026-08-03-api-selection-design.md`. Fix every critical and important finding, rerun all verification, commit fixes, and obtain a ready-to-merge verdict.

--- a/docs/superpowers/plans/2026-08-03-http-debug-logging.md
+++ b/docs/superpowers/plans/2026-08-03-http-debug-logging.md
@@ -1,0 +1,168 @@
+# HTTP Debug Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit a safe debug record for every successfully constructed HTTP request made by the shared Workflowy client.
+
+**Architecture:** Keep HTTP diagnostics inside `pkg/client.Client.Do`, the seam crossed by CLI and MCP network operations. Let `slog` level filtering control visibility, remove the GET-only context plumbing, and document the same behavior for both interfaces.
+
+**Tech Stack:** Go 1.24, `log/slog`, `net/http`, `testify`, urfave/cli, Markdown, `just`
+
+---
+
+## Chunk 1: Implement and document all-request HTTP debug logging
+
+### Task 1: Make client tests describe unconditional debug logging
+
+**Files:**
+- Modify and add to Git: `pkg/client/client_test.go` (currently untracked)
+
+- [ ] **Step 1: Remove the context opt-in from the debug-level test**
+
+Call `Client.Do` with `context.Background()` and keep assertions for the debug level, message, method, and path:
+
+```go
+err := client.Do(context.Background(), method, "/nodes/test-id", nil, nil)
+```
+
+- [ ] **Step 2: Make the logger threshold explicit**
+
+Replace the debug-only test helper with:
+
+```go
+func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+
+	var output bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: level}))
+	previous := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	return &output
+}
+```
+
+Use `slog.LevelDebug` in the emission test. Rename the suppression test to `TestClientDo_DoesNotLogHTTPRequestsAtInfoLevel`, use `slog.LevelInfo`, and loop over the same GET, POST, and DELETE cases so both level behaviors cover every supported method shape. Do not mark either test parallel because they replace the process-global logger.
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+Run: `go test ./pkg/client -run 'TestClientDo' -count=1`
+
+Expected: FAIL because `Client.Do` still requires the removed context marker before submitting the record.
+
+### Task 2: Centralize logging at the HTTP transport seam
+
+**Files:**
+- Modify: `pkg/client/client.go`
+- Delete from the working tree: `pkg/client/context.go` (currently untracked, so no staged deletion is expected)
+- Modify: `cmd/workflowy/fetch.go`
+- Modify: `cmd/workflowy/fetch_test.go`
+
+- [ ] **Step 1: Log every successfully constructed request**
+
+Remove the context condition near the start of `Client.Do`. Immediately before `c.http.Do(req)`, add:
+
+```go
+slog.Debug("http request", "method", method, "path", path)
+
+resp, err := c.http.Do(req)
+```
+
+Do not log the resolved URL, headers, authentication, request body, or response body.
+
+- [ ] **Step 2: Remove the obsolete context interface**
+
+Delete `pkg/client/context.go`, which contains `WithDebugHTTPLogging` and `DebugHTTPLoggingEnabled`.
+
+- [ ] **Step 3: Remove GET-specific caller plumbing**
+
+In `cmd/workflowy/fetch.go`, remove the `pkg/client` import and this line from the GET branch:
+
+```go
+apiCtx = clientpkg.WithDebugHTTPLogging(apiCtx)
+```
+
+- [ ] **Step 4: Remove the obsolete context-propagation test**
+
+In `cmd/workflowy/fetch_test.go`, remove `TestFetchItems_GetMethod_EnablesHTTPDebugLoggingOnFetcherRequests`, `debugLoggingClient`, and the imports used only by them.
+
+- [ ] **Step 5: Format and run focused tests to verify GREEN**
+
+Run:
+
+```bash
+gofmt -w pkg/client/client.go pkg/client/client_test.go cmd/workflowy/fetch.go cmd/workflowy/fetch_test.go
+go test ./pkg/client ./cmd/workflowy -count=1
+```
+
+Expected: both packages PASS.
+
+- [ ] **Step 6: Commit the focused code change**
+
+```bash
+git add pkg/client/client.go pkg/client/client_test.go cmd/workflowy/fetch.go cmd/workflowy/fetch_test.go
+git commit -m "feat: log all HTTP requests at debug level"
+```
+
+Only files with actual tracked changes will be included; the restored fetch files should match `HEAD`.
+
+### Task 3: Document CLI and MCP troubleshooting behavior
+
+**Files:**
+- Modify: `docs/CLI.md`
+- Modify: `docs/MCP.md`
+
+- [ ] **Step 1: Add the CLI troubleshooting example**
+
+Under `docs/CLI.md` → `Troubleshooting`, document that `workflowy get <id> --log=debug` shows the method and path for every API request and never logs API keys, authorization headers, or request bodies.
+
+- [ ] **Step 2: Add the MCP logging example**
+
+Under `docs/MCP.md` → `Logging and Debugging`, add this example and the same safety statement:
+
+```text
+DEBUG: http request (method='GET', path='/nodes/example')
+```
+
+- [ ] **Step 3: Commit documentation parity**
+
+```bash
+git add docs/CLI.md docs/MCP.md
+git commit -m "docs: describe HTTP debug logging"
+```
+
+### Task 4: Verify the complete change
+
+**Files:**
+- Verify only; no planned file changes
+
+- [ ] **Step 1: Check formatting and whitespace**
+
+Run:
+
+```bash
+gofmt -w pkg/client/client.go pkg/client/client_test.go cmd/workflowy/fetch.go cmd/workflowy/fetch_test.go
+git diff --check
+```
+
+Expected: no output from `git diff --check`.
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `just test`
+
+Expected: all packages PASS, including `pkg/client`, `cmd/workflowy`, and `scripts`.
+
+- [ ] **Step 3: Run static analysis**
+
+Run: `go vet ./...`
+
+Expected: exit status 0 with no diagnostics.
+
+- [ ] **Step 4: Inspect final scope**
+
+Run `git status --short` and `git log -5 --oneline`.
+
+Expected: because this plan is committed before execution, only the pre-existing untracked curl helper and generated `.gocache/` remain outside the committed HTTP logging change.

--- a/docs/superpowers/plans/2026-08-03-http-debug-logging.md
+++ b/docs/superpowers/plans/2026-08-03-http-debug-logging.md
@@ -123,7 +123,7 @@ Under `docs/CLI.md` → `Troubleshooting`, document that `workflowy get <id> --l
 Under `docs/MCP.md` → `Logging and Debugging`, add this example and the same safety statement:
 
 ```text
-DEBUG: http request (method='GET', path='/nodes/example')
+DEBUG: http request (method='GET' path='/nodes/example')
 ```
 
 - [ ] **Step 3: Commit documentation parity**

--- a/docs/superpowers/specs/2026-08-03-api-selection-design.md
+++ b/docs/superpowers/specs/2026-08-03-api-selection-design.md
@@ -36,11 +36,13 @@ workflowy mcp --api=beta
 
 The flag follows the existing command-local flag convention, so it can appear after the subcommand. Commands that are entirely local and never construct a Workflowy client do not need the flag.
 
+The flag is present on `get`, `list`, `create`, `update`, `move`, `delete`, `complete`, `uncomplete`, `targets`, `search`, `replace`, `transform`, `id`, `mcp`, and every `report` subcommand. Reports receive it because they may load data from the API or upload their result, even when a particular invocation reads its input from a backup. `version` is the only current command that does not receive it.
+
 ### MCP
 
 The MCP server accepts `--api=production|beta`. This establishes the default deployment for all tools hosted by that process.
 
-Every MCP tool that can make a Workflowy network request accepts an optional string argument:
+Every MCP tool that can make a Workflowy network request accepts an optional string argument constrained by its schema to the enum values `production` and `beta`:
 
 ```json
 {
@@ -55,6 +57,8 @@ tool api argument > MCP server --api flag > production
 ```
 
 Tools that exclusively read a local backup, such as the current mirror report, do not expose a meaningless per-tool `api` argument. The MCP server may still be started with `--api` when those tools are enabled alongside network-capable tools.
+
+The argument is present on `workflowy_get`, `workflowy_list`, `workflowy_search`, `workflowy_targets`, `workflowy_id`, `workflowy_create`, `workflowy_update`, `workflowy_move`, `workflowy_delete`, `workflowy_complete`, `workflowy_uncomplete`, `workflowy_report_count`, `workflowy_report_children`, `workflowy_report_created`, `workflowy_report_modified`, `workflowy_replace`, and `workflowy_transform`. It is absent only from the current backup-only `workflowy_report_mirrors` tool.
 
 ### Relationship to Access Method
 
@@ -101,18 +105,28 @@ At the start of an MCP invocation, the tool builder resolves the requested deplo
 
 The deployment value must be passed explicitly through this seam. It must not be stored in a mutable global or hidden in a context value.
 
+CLI command construction and the MCP tool builder accept an internal client factory whose interface maps a validated deployment to a `workflowy.Client`. The production adapter constructs clients from the fixed deployment mapping. Tests replace the adapter with recording clients or local HTTP clients, so they can verify selection without DNS changes or real network requests. This is an internal testing seam, not a user-facing custom-host option.
+
+### MCP Restriction Roots
+
+`read_root_id` and `write_root_id` are deployment-relative inputs when they are target keys or short IDs. Resolving either value once with the server default and reusing the result after a tool-level override would violate the promise that the complete invocation uses one deployment.
+
+The MCP server therefore retains the raw configured root values. After selecting the effective client for a tool call, it resolves both active roots with that same client before performing ID resolution, access validation, or the requested operation. The resulting UUIDs exist only for that invocation and are never reused by an invocation selecting the other deployment.
+
+Resolution errors identify both the root value and the selected deployment. A root that resolves in production but not beta prevents only beta-selected invocations; it does not prevent an otherwise production-configured MCP server from starting. Export caching already limits repeated short-ID resolution requests, and additional root memoization is outside this feature until measurements show it is needed.
+
 ### Export Cache Isolation
 
 Production and beta export responses must not share a cache entry. Otherwise a beta request could return production data without making a request, or the reverse.
 
-The cache module therefore selects its cache file by deployment:
+Each Workflowy client owns an explicit export-cache path selected when that client is constructed:
 
 | Deployment | Cache file |
 | --- | --- |
 | `production` | `~/.workflowy/export-cache.json` |
 | `beta` | `~/.workflowy/export-cache-beta.json` |
 
-Keeping the existing path for production preserves current behavior and existing caches. Beta receives a new isolated path. Cache reads, stale-cache fallback, writes, and export rate-limit timing all use the selected deployment's file.
+Keeping the existing path for production preserves current behavior and existing caches. Beta receives a new isolated path. The cache module's read and write interfaces accept the path explicitly; they do not consult package-global deployment state. Cache reads, stale-cache fallback, writes, and export rate-limit timing all use the path owned by the selected client. Tests supply temporary paths to verify isolation without touching the user's cache.
 
 Backup-file access is deployment-independent and remains unchanged.
 
@@ -131,10 +145,12 @@ Backup-file access is deployment-independent and remains unchanged.
 
 1. Parse and validate the server's `--api` during startup, defaulting to `production`.
 2. Construct authenticated clients for production and beta.
-3. For each tool call, read the optional `api` argument.
-4. Resolve the effective deployment using the documented precedence.
-5. Select the corresponding client before any ID resolution or validation.
-6. Use that client for every network operation made by the tool call.
+3. Retain configured read and write root values without resolving them against either deployment.
+4. For each tool call, read the optional `api` argument.
+5. Resolve the effective deployment using the documented precedence.
+6. Select the corresponding client.
+7. Resolve active read and write roots with that client.
+8. Use that client and those per-invocation roots for every ID resolution, validation, and network operation made by the tool call.
 
 ## Validation and Error Handling
 
@@ -145,6 +161,12 @@ Cannot select Workflowy API "staging": expected "production" or "beta"
 ```
 
 CLI validation returns the error from the command. An invalid MCP server default prevents startup. An invalid per-tool override returns an MCP tool error and leaves the server running.
+
+An MCP restriction root that cannot be resolved returns a contextual tool error such as:
+
+```text
+Cannot resolve read root "inbox" using Workflowy API "beta": <cause>
+```
 
 Network errors continue to use the existing operation-specific wrapping. Debug logging includes the selected deployment and request path, but authentication material is never logged.
 
@@ -160,8 +182,11 @@ Unit tests cover:
 - MCP uses its server default when a tool omits `api`;
 - an MCP tool argument overrides the server default;
 - all requests within an MCP invocation, including ID resolution and access validation, use the selected client;
+- read and write roots are resolved with the effective per-invocation client;
+- a root-resolution failure in beta does not prevent production invocations or MCP startup;
 - production and beta exports use different cache files;
 - the production cache retains its existing path;
+- two clients in the same process cannot read or write each other's cache entries;
 - `method=backup` performs no network request regardless of API selection.
 
 Existing production-default tests must continue to pass. Test coverage must not decrease.

--- a/docs/superpowers/specs/2026-08-03-api-selection-design.md
+++ b/docs/superpowers/specs/2026-08-03-api-selection-design.md
@@ -1,0 +1,203 @@
+# Workflowy API Selection Design
+
+## Summary
+
+Allow users to choose whether network operations use Workflowy's production or beta API. The production API remains the default. The CLI exposes the choice through `--api`, while MCP supports both a server-wide `--api` default and an optional `api` argument on each network-capable tool.
+
+This change selects the Workflowy deployment only. It does not normalize the different response contracts or add mirror-specific behavior. Those changes can build on this selection interface later.
+
+## Motivation
+
+The Workflowy production and beta deployments expose the same endpoint paths under different hosts, but their response contracts differ. For example, the production retrieve response documents `parent_id` and `completed`, while the beta retrieve response omits them. Users need an explicit way to run the CLI and MCP tools against either deployment while the beta contract evolves.
+
+References:
+
+- Production: <https://workflowy.com/api-reference/#nodes-retrieve>
+- Beta: <https://beta.workflowy.com/api-reference/#nodes-retrieve>
+
+## User Interface
+
+### CLI
+
+All commands that can construct a Workflowy network client accept:
+
+```text
+--api <production|beta>
+    Workflowy API deployment to use (default: production)
+```
+
+Examples:
+
+```bash
+workflowy get <id> --api=beta
+workflowy create "Node" --api=production
+workflowy mcp --api=beta
+```
+
+The flag follows the existing command-local flag convention, so it can appear after the subcommand. Commands that are entirely local and never construct a Workflowy client do not need the flag.
+
+### MCP
+
+The MCP server accepts `--api=production|beta`. This establishes the default deployment for all tools hosted by that process.
+
+Every MCP tool that can make a Workflowy network request accepts an optional string argument:
+
+```json
+{
+  "api": "beta"
+}
+```
+
+The per-tool argument overrides the server default for the complete tool invocation, including ID resolution, access validation, reads, and writes. The precedence is:
+
+```text
+tool api argument > MCP server --api flag > production
+```
+
+Tools that exclusively read a local backup, such as the current mirror report, do not expose a meaningless per-tool `api` argument. The MCP server may still be started with `--api` when those tools are enabled alongside network-capable tools.
+
+### Relationship to Access Method
+
+`api` and `method` describe separate decisions:
+
+- `api` chooses the Workflowy deployment: `production` or `beta`.
+- `method` chooses the data access mechanism: `get`, `export`, or `backup`.
+
+When `method=backup`, no network request occurs and the selected API has no effect. This combination remains valid so global CLI and MCP defaults do not require special casing.
+
+## Domain Model
+
+The API deployment is a closed value with two valid members:
+
+| Value | Base URL |
+| --- | --- |
+| `production` | `https://workflowy.com/api/v1` |
+| `beta` | `https://beta.workflowy.com/api/v1` |
+
+The canonical user-facing values are the full words `production` and `beta`. Aliases such as `prod`, arbitrary URLs, and environment names such as `staging` are not accepted.
+
+Deployment selection is not an API version. Both deployments currently use the `/api/v1` path, so naming the option `api_version` would establish the wrong semantics.
+
+## Module Design
+
+### Deployment Selection Module
+
+A small Workflowy package module owns:
+
+- the valid deployment values;
+- parsing and validation;
+- the mapping from deployment to base URL;
+- the production default.
+
+Its interface returns a categorized deployment value or a contextual error. Callers do not construct or compare base URLs themselves. This concentrates host knowledge at one seam and prevents CLI and MCP behavior from drifting.
+
+### Client Construction
+
+Workflowy client construction accepts a validated deployment and authentication options. The generic HTTP client continues to accept a base URL, but only the Workflowy-specific constructor performs the deployment-to-host mapping.
+
+The CLI validates its `--api` value before constructing one client for the command. MCP retains clients for both deployments, using the same resolved API key, because any tool invocation may override the server default. Client construction performs no network request.
+
+At the start of an MCP invocation, the tool builder resolves the requested deployment and uses that client throughout the invocation. Selection must happen before ID resolution and read/write guard checks so every network request in one invocation goes to the same deployment.
+
+The deployment value must be passed explicitly through this seam. It must not be stored in a mutable global or hidden in a context value.
+
+### Export Cache Isolation
+
+Production and beta export responses must not share a cache entry. Otherwise a beta request could return production data without making a request, or the reverse.
+
+The cache module therefore selects its cache file by deployment:
+
+| Deployment | Cache file |
+| --- | --- |
+| `production` | `~/.workflowy/export-cache.json` |
+| `beta` | `~/.workflowy/export-cache-beta.json` |
+
+Keeping the existing path for production preserves current behavior and existing caches. Beta receives a new isolated path. Cache reads, stale-cache fallback, writes, and export rate-limit timing all use the selected deployment's file.
+
+Backup-file access is deployment-independent and remains unchanged.
+
+## Data Flow
+
+### CLI Command
+
+1. Parse `--api`, defaulting to `production`.
+2. Validate the value and map it to a deployment.
+3. Resolve the API key using the existing precedence rules.
+4. Construct a Workflowy client for the deployment.
+5. Run ID resolution, access validation, and the requested operation with that client.
+6. If the operation uses export, read and write only that deployment's cache.
+
+### MCP Tool Invocation
+
+1. Parse and validate the server's `--api` during startup, defaulting to `production`.
+2. Construct authenticated clients for production and beta.
+3. For each tool call, read the optional `api` argument.
+4. Resolve the effective deployment using the documented precedence.
+5. Select the corresponding client before any ID resolution or validation.
+6. Use that client for every network operation made by the tool call.
+
+## Validation and Error Handling
+
+Invalid CLI and MCP values fail without making a network request. New user-facing errors follow the repository convention and include the rejected value:
+
+```text
+Cannot select Workflowy API "staging": expected "production" or "beta"
+```
+
+CLI validation returns the error from the command. An invalid MCP server default prevents startup. An invalid per-tool override returns an MCP tool error and leaves the server running.
+
+Network errors continue to use the existing operation-specific wrapping. Debug logging includes the selected deployment and request path, but authentication material is never logged.
+
+## Testing
+
+Unit tests cover:
+
+- an omitted value resolves to `production`;
+- `production` maps to `https://workflowy.com/api/v1`;
+- `beta` maps to `https://beta.workflowy.com/api/v1`;
+- invalid values return a contextual error containing the rejected value and valid choices;
+- CLI commands send requests to the selected test server adapter;
+- MCP uses its server default when a tool omits `api`;
+- an MCP tool argument overrides the server default;
+- all requests within an MCP invocation, including ID resolution and access validation, use the selected client;
+- production and beta exports use different cache files;
+- the production cache retains its existing path;
+- `method=backup` performs no network request regardless of API selection.
+
+Existing production-default tests must continue to pass. Test coverage must not decrease.
+
+Integration tests cover at least one read-only command against each deployment when credentials and network access are explicitly available. They belong under the existing read-only integration target; this feature does not add destructive integration coverage.
+
+## Documentation
+
+The same change updates:
+
+- the README's CLI and MCP setup examples;
+- `docs/CLI.md`, including the option, valid values, default, and interaction with `method`;
+- `docs/MCP.md`, including server-wide configuration, per-tool overrides, and precedence;
+- MCP tool schemas for every network-capable tool.
+
+The documentation must continue to describe production as the default and beta as opt-in.
+
+## Alternatives Rejected
+
+### Boolean Beta Flag
+
+`--beta-api` and `beta_api` are initially short but create asymmetric negation and do not model two named deployments cleanly.
+
+### Arbitrary Base URL
+
+`--api-base-url` exposes infrastructure details, expands the supported surface to unrequested custom endpoints, and makes validation and documentation weaker.
+
+### API Environment Name
+
+`--api-environment` is accurate but unnecessarily verbose. `api` is clear when its closed set of values is shown in help and MCP schemas.
+
+## Non-Goals
+
+- Normalizing production and beta node response shapes.
+- Implementing new mirror behavior.
+- Automatically detecting which deployment supports an operation.
+- Falling back from one deployment to the other after an error.
+- Supporting arbitrary Workflowy hosts or custom base URLs.
+- Selecting separate API keys per deployment.

--- a/docs/superpowers/specs/2026-08-03-api-selection-design.md
+++ b/docs/superpowers/specs/2026-08-03-api-selection-design.md
@@ -8,7 +8,7 @@ This change selects the Workflowy deployment only. It does not normalize the dif
 
 ## Motivation
 
-The Workflowy production and beta deployments expose the same endpoint paths under different hosts, but their response contracts differ. For example, the production retrieve response documents `parent_id` and `completed`, while the beta retrieve response omits them. Users need an explicit way to run the CLI and MCP tools against either deployment while the beta contract evolves.
+The Workflowy production and beta deployments expose the same endpoint paths under different hosts, but their capabilities and response contracts differ. Most notably, the beta API supports mirrors and exposes `data.mirror.origin_id` when retrieving a mirror node, while the current production API does not. Users need an explicit way to run the CLI and MCP tools against either deployment while the beta contract evolves.
 
 References:
 
@@ -67,7 +67,7 @@ The argument is present on `workflowy_get`, `workflowy_list`, `workflowy_search`
 - `api` chooses the Workflowy deployment: `production` or `beta`.
 - `method` chooses the data access mechanism: `get`, `export`, or `backup`.
 
-When `method=backup`, no network request occurs and the selected API has no effect. This combination remains valid so global CLI and MCP defaults do not require special casing.
+`method=backup` selects the local source for reading and access validation; it does not imply that the entire command is read-only. A read-only backup invocation can remain fully offline, while a mutation, transform application, replacement, or report upload still sends writes through the API selected by `api`. The combination remains valid, and `api` is meaningful whenever any part of the invocation performs a network request.
 
 ## Domain Model
 
@@ -101,7 +101,7 @@ Workflowy client construction accepts a validated deployment and authentication 
 
 The CLI validates its `--api` value before constructing one client for the command. MCP retains clients for both deployments, using the same resolved API key, because any tool invocation may override the server default. Client construction performs no network request.
 
-At the start of an MCP invocation, the tool builder resolves the requested deployment and uses that client throughout the invocation. Selection must happen before ID resolution and read/write guard checks so every network request in one invocation goes to the same deployment.
+At the start of an MCP invocation, the tool builder resolves the requested deployment and selects the corresponding client for any network work. Selection must happen before network-backed ID resolution and read/write guard checks so every network request in one invocation goes to the same deployment. Local backup reads continue to use the backup provider.
 
 The deployment value must be passed explicitly through this seam. It must not be stored in a mutable global or hidden in a context value.
 
@@ -109,11 +109,15 @@ CLI command construction and the MCP tool builder accept an internal client fact
 
 ### MCP Restriction Roots
 
-`read_root_id` and `write_root_id` are deployment-relative inputs when they are target keys or short IDs. Resolving either value once with the server default and reusing the result after a tool-level override would violate the promise that the complete invocation uses one deployment.
+`read_root_id` and `write_root_id` must be resolved against the same source used for access validation. Resolving either value once with the server default and reusing the result after a tool-level override would violate the promise that all network activity in an invocation uses one deployment. Always resolving through a network client would also break offline backup reads.
 
-The MCP server therefore retains the raw configured root values. After selecting the effective client for a tool call, it resolves both active roots with that same client before performing ID resolution, access validation, or the requested operation. The resulting UUIDs exist only for that invocation and are never reused by an invocation selecting the other deployment.
+The MCP server therefore retains the raw configured root values and resolves the effective access method before resolving roots:
 
-Resolution errors identify both the root value and the selected deployment. A root that resolves in production but not beta prevents only beta-selected invocations; it does not prevent an otherwise production-configured MCP server from starting. Export caching already limits repeated short-ID resolution requests, and additional root memoization is outside this feature until measurements show it is needed.
+- With `get` or `export`, root target keys and short IDs resolve through the selected deployment and are verified against the selected deployment's export tree.
+- With `backup`, full UUIDs are verified in the backup tree and short IDs are resolved by matching that tree. This path performs no network request.
+- A target-key restriction cannot be resolved from the current backup format. A backup invocation using one fails contextually and instructs the user to configure the restriction with a full or short node ID. It does not silently contact either API.
+
+The resulting UUIDs exist only for that invocation and are never reused by an invocation selecting a different deployment or validation source. Resolution errors identify the root value and either the selected deployment or backup file. A root that resolves in production but not beta prevents only beta-selected invocations; it does not prevent an otherwise production-configured MCP server from starting. Export caching already limits repeated network-based short-ID resolution requests, and additional root memoization is outside this feature until measurements show it is needed.
 
 ### Export Cache Isolation
 
@@ -146,11 +150,11 @@ Backup-file access is deployment-independent and remains unchanged.
 1. Parse and validate the server's `--api` during startup, defaulting to `production`.
 2. Construct authenticated clients for production and beta.
 3. Retain configured read and write root values without resolving them against either deployment.
-4. For each tool call, read the optional `api` argument.
-5. Resolve the effective deployment using the documented precedence.
-6. Select the corresponding client.
-7. Resolve active read and write roots with that client.
-8. Use that client and those per-invocation roots for every ID resolution, validation, and network operation made by the tool call.
+4. For each tool call, read the optional `api` and `method` arguments.
+5. Resolve the effective deployment and access method using their documented precedence rules.
+6. Select the corresponding client and the validation source for the effective method.
+7. Resolve active read and write roots against that validation source.
+8. Use those per-invocation roots for validation and the selected client for every network operation made by the tool call.
 
 ## Validation and Error Handling
 
@@ -168,6 +172,12 @@ An MCP restriction root that cannot be resolved returns a contextual tool error 
 Cannot resolve read root "inbox" using Workflowy API "beta": <cause>
 ```
 
+A target-key root requested with backup remains offline and reports the corrective action:
+
+```text
+Cannot resolve read root "inbox" from backup "<path>": target keys require an API; configure read_root_id with a full or short node ID
+```
+
 Network errors continue to use the existing operation-specific wrapping. Debug logging includes the selected deployment and request path, but authentication material is never logged.
 
 ## Testing
@@ -181,13 +191,16 @@ Unit tests cover:
 - CLI commands send requests to the selected test server adapter;
 - MCP uses its server default when a tool omits `api`;
 - an MCP tool argument overrides the server default;
-- all requests within an MCP invocation, including ID resolution and access validation, use the selected client;
-- read and write roots are resolved with the effective per-invocation client;
+- all network requests within an MCP invocation, including network-backed ID resolution and access validation, use the selected client;
+- read and write roots are resolved with the effective per-invocation validation source;
 - a root-resolution failure in beta does not prevent production invocations or MCP startup;
+- full and short restriction IDs resolve locally when validation uses a backup;
+- a target-key restriction with backup fails contextually without making a network request;
 - production and beta exports use different cache files;
 - the production cache retains its existing path;
 - two clients in the same process cannot read or write each other's cache entries;
-- `method=backup` performs no network request regardless of API selection.
+- a read-only backup invocation using locally resolvable IDs performs no network request regardless of API selection;
+- writes and report uploads use the selected deployment even when their read or validation source is a backup.
 
 Existing production-default tests must continue to pass. Test coverage must not decrease.
 

--- a/docs/superpowers/specs/2026-08-03-http-debug-logging-design.md
+++ b/docs/superpowers/specs/2026-08-03-http-debug-logging-design.md
@@ -13,7 +13,7 @@ The current uncommitted implementation enables HTTP request logging through a co
 `Client.Do` emits this structured record immediately before sending every successfully constructed HTTP request:
 
 ```text
-DEBUG: http request (method='GET', path='/nodes/example')
+DEBUG: http request (method='GET' path='/nodes/example')
 ```
 
 The call to `slog.Debug` is unconditional. The configured logging handler decides whether the record is emitted:

--- a/docs/superpowers/specs/2026-08-03-http-debug-logging-design.md
+++ b/docs/superpowers/specs/2026-08-03-http-debug-logging-design.md
@@ -1,0 +1,79 @@
+# HTTP Debug Logging Design
+
+## Summary
+
+Log every Workflowy HTTP request at debug level from the generic HTTP client's request seam. The log record includes the HTTP method and request path but never includes authentication headers or request bodies.
+
+## Motivation
+
+The current uncommitted implementation enables HTTP request logging through a context value set only by the CLI's GET fetch path. As a result, export calls, writes, report uploads, MCP operations, and other HTTP requests do not produce the same diagnostic record. HTTP logging is a transport concern and should be implemented consistently where all requests pass through the client.
+
+## Behavior
+
+`Client.Do` emits this structured record immediately before sending every successfully constructed HTTP request:
+
+```text
+DEBUG: http request (method='GET', path='/nodes/example')
+```
+
+The call to `slog.Debug` is unconditional. The configured logging handler decides whether the record is emitted:
+
+- `--log=debug` emits the record.
+- The default `--log=info` and higher levels suppress it.
+
+The record includes only:
+
+- `method`: the HTTP method passed to `Client.Do`;
+- `path`: the relative request path passed to `Client.Do`.
+
+It must not include the authorization header, API key, request body, or response body.
+
+This applies uniformly to CLI and MCP requests, including GET, export, create, update, move, complete, uncomplete, delete, target-listing, report-upload, replace, and transform operations.
+
+## Module Design
+
+The generic HTTP client is the single module responsible for the diagnostic record because every Workflowy network operation crosses its `Do` interface. Callers do not opt in through context values and do not need to know how HTTP logging is implemented.
+
+The context helpers `WithDebugHTTPLogging` and `DebugHTTPLoggingEnabled` are removed, along with the GET-specific call in `fetchItems`. No logging transport wrapper or additional configuration type is introduced.
+
+The existing logging configuration remains the only user-facing control. This keeps the interface small and avoids duplicating log-level state in request contexts.
+
+## Data Flow
+
+1. A CLI or MCP operation calls a Workflowy client method.
+2. The Workflowy client method calls `Client.Do` with a method and relative path.
+3. `Client.Do` encodes the body, constructs the request, sets headers, and applies authentication as before.
+4. Immediately before calling the HTTP transport, `Client.Do` submits the structured debug record to `slog`.
+5. The configured handler emits or suppresses the record according to its level.
+6. `Client.Do` sends the HTTP request as before.
+
+Logging does not alter request construction, authentication, response decoding, or error handling.
+
+## Error Handling
+
+Logging introduces no new error path. `slog.Debug` does not return an error, and request errors continue through the existing client behavior unchanged.
+
+## Testing
+
+Unit tests verify:
+
+- GET, POST, and DELETE calls submit a record containing the method and path when the logger accepts debug records;
+- the same calls do not appear when the logger threshold is info;
+- no context marker is required;
+- request execution and response handling remain unchanged.
+
+Tests that replace the process-global default logger restore it with `t.Cleanup` and do not run in parallel.
+
+The GET-specific context-propagation test is removed because that interface no longer exists. The full unit suite and `go vet ./...` must pass.
+
+## Documentation
+
+Existing `--log` documentation already describes the `debug` level. Update both `docs/CLI.md` and `docs/MCP.md` with a concise troubleshooting example showing that `--log=debug` reports HTTP method and path for all API operations. No new CLI or MCP parameter is introduced.
+
+## Non-Goals
+
+- Logging headers, API keys, or bodies.
+- Logging response bodies.
+- Adding a second HTTP-logging flag.
+- Changing the format of non-HTTP log records.
+- Fixing the separate curl helper's credential-handling or error-reporting issues.

--- a/pkg/cache/export.go
+++ b/pkg/cache/export.go
@@ -23,34 +23,29 @@ type ExportCache struct {
 	Data      json.RawMessage `json:"data"`
 }
 
-// GetCachePath returns the full path to the cache file
-func GetCachePath() (string, error) {
+// GetCachePath returns the full path to a cache file beneath the user's home directory.
+func GetCachePath(relativePath string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("could not get home directory: %w", err)
+		return "", fmt.Errorf("Cannot resolve cache path %q: cannot get home directory: %w", relativePath, err)
 	}
-	return filepath.Join(homeDir, DefaultCacheFile), nil
+	return filepath.Join(homeDir, relativePath), nil
 }
 
 // ReadExportCache reads the cached export data if it exists and is valid
-func ReadExportCache() (*ExportCache, error) {
-	cachePath, err := GetCachePath()
-	if err != nil {
-		return nil, err
-	}
-
+func ReadExportCache(cachePath string) (*ExportCache, error) {
 	data, err := os.ReadFile(cachePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			slog.Debug("cache file does not exist", "path", cachePath)
 			return nil, nil // No cache exists, not an error
 		}
-		return nil, fmt.Errorf("cannot read cache file: %w", err)
+		return nil, fmt.Errorf("Cannot read export cache %q: %w", cachePath, err)
 	}
 
 	var cache ExportCache
 	if err := json.Unmarshal(data, &cache); err != nil {
-		return nil, fmt.Errorf("cannot parse cache file: %w", err)
+		return nil, fmt.Errorf("Cannot parse export cache %q: %w", cachePath, err)
 	}
 
 	slog.Debug("cache file read successfully", "path", cachePath, "timestamp", cache.Timestamp)
@@ -59,22 +54,17 @@ func ReadExportCache() (*ExportCache, error) {
 
 // WriteExportCache writes the export data to cache with current timestamp
 // data should be any type that can be marshaled to JSON
-func WriteExportCache(data interface{}) error {
-	cachePath, err := GetCachePath()
-	if err != nil {
-		return err
-	}
-
+func WriteExportCache(cachePath string, data interface{}) error {
 	// Ensure cache directory exists
 	cacheDir := filepath.Dir(cachePath)
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		return fmt.Errorf("cannot create cache directory: %w", err)
+		return fmt.Errorf("Cannot create export cache directory %q: %w", cacheDir, err)
 	}
 
 	// Marshal the data to JSON
 	dataJSON, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("cannot encode data: %w", err)
+		return fmt.Errorf("Cannot encode export cache data for %q: %w", cachePath, err)
 	}
 
 	cache := ExportCache{
@@ -84,11 +74,11 @@ func WriteExportCache(data interface{}) error {
 
 	cacheData, err := json.MarshalIndent(cache, "", "  ")
 	if err != nil {
-		return fmt.Errorf("cannot encode cache data: %w", err)
+		return fmt.Errorf("Cannot encode export cache document for %q: %w", cachePath, err)
 	}
 
 	if err := os.WriteFile(cachePath, cacheData, 0644); err != nil {
-		return fmt.Errorf("cannot write cache file: %w", err)
+		return fmt.Errorf("Cannot write export cache %q: %w", cachePath, err)
 	}
 
 	slog.Debug("cache file written", "path", cachePath, "timestamp", cache.Timestamp)

--- a/pkg/cache/export_test.go
+++ b/pkg/cache/export_test.go
@@ -1,0 +1,35 @@
+package cache
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportCacheIsolation(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	productionPath := filepath.Join(temporaryDirectory, "production", "export.json")
+	betaPath := filepath.Join(temporaryDirectory, "beta", "export.json")
+
+	require.NoError(t, WriteExportCache(productionPath, map[string]string{"deployment": "production"}))
+	require.NoError(t, WriteExportCache(betaPath, map[string]string{"deployment": "beta"}))
+
+	productionCache, err := ReadExportCache(productionPath)
+	require.NoError(t, err)
+	require.NotNil(t, productionCache)
+
+	betaCache, err := ReadExportCache(betaPath)
+	require.NoError(t, err)
+	require.NotNil(t, betaCache)
+
+	var productionPayload map[string]string
+	require.NoError(t, json.Unmarshal(productionCache.Data, &productionPayload))
+	assert.Equal(t, map[string]string{"deployment": "production"}, productionPayload)
+
+	var betaPayload map[string]string
+	require.NoError(t, json.Unmarshal(betaCache.Data, &betaPayload))
+	assert.Equal(t, map[string]string{"deployment": "beta"}, betaPayload)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -63,6 +64,8 @@ func (c *Client) Do(ctx context.Context, method, path string, in any, out any) e
 	}
 
 	c.auth(req)
+
+	slog.Debug("http request", "method", method, "path", path)
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -13,9 +13,10 @@ import (
 )
 
 type Client struct {
-	baseURL string
-	http    *http.Client
-	auth    func(r *http.Request) // injects auth headers
+	baseURL       string
+	http          *http.Client
+	auth          func(r *http.Request) // injects auth headers
+	logAttributes []slog.Attr
 }
 
 // SetAuth allows setting the auth function after client creation
@@ -24,6 +25,13 @@ func (c *Client) SetAuth(authFunc func(r *http.Request)) {
 }
 
 type Option func(*Client)
+
+// WithLogAttributes adds stable context to every HTTP request log record.
+func WithLogAttributes(attributes ...slog.Attr) Option {
+	return func(client *Client) {
+		client.logAttributes = append(client.logAttributes, attributes...)
+	}
+}
 
 func New(base string, opts ...Option) *Client {
 	c := &Client{
@@ -65,7 +73,12 @@ func (c *Client) Do(ctx context.Context, method, path string, in any, out any) e
 
 	c.auth(req)
 
-	slog.Debug("http request", "method", method, "path", path)
+	attributes := []slog.Attr{
+		slog.String("method", method),
+		slog.String("path", path),
+	}
+	attributes = append(attributes, c.logAttributes...)
+	slog.LogAttrs(ctx, slog.LevelDebug, "http request", attributes...)
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestClientDo_LogsHTTPRequestsAtDebugLevel(t *testing.T) {
 	output := captureLogs(t, slog.LevelDebug)
-	c := newSuccessfulTestClient()
+	c := newTestClient(http.StatusOK, `{}`)
 
 	for _, method := range []string{"GET", "POST", "DELETE"} {
 		output.Reset()
@@ -32,7 +32,7 @@ func TestClientDo_LogsHTTPRequestsAtDebugLevel(t *testing.T) {
 
 func TestClientDo_DoesNotLogHTTPRequestsAtInfoLevel(t *testing.T) {
 	output := captureLogs(t, slog.LevelInfo)
-	c := newSuccessfulTestClient()
+	c := newTestClient(http.StatusOK, `{}`)
 
 	for _, method := range []string{"GET", "POST", "DELETE"} {
 		output.Reset()
@@ -42,6 +42,33 @@ func TestClientDo_DoesNotLogHTTPRequestsAtInfoLevel(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotContains(t, strings.TrimSpace(output.String()), "msg=\"http request\"")
 	}
+}
+
+func TestClientDo_LogsAndDecodesSuccessfulResponse(t *testing.T) {
+	output := captureLogs(t, slog.LevelDebug)
+	c := newTestClient(http.StatusOK, `{"status":"ok"}`)
+	var response struct {
+		Status string `json:"status"`
+	}
+
+	err := c.Do(context.Background(), "GET", "/nodes/test-id", nil, &response)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", response.Status)
+	assert.Contains(t, output.String(), "msg=\"http request\"")
+}
+
+func TestClientDo_LogsRequestReturningAPIError(t *testing.T) {
+	output := captureLogs(t, slog.LevelDebug)
+	c := newTestClient(http.StatusBadRequest, `{"error":"invalid request"}`)
+
+	err := c.Do(context.Background(), "POST", "/nodes/test-id", nil, nil)
+
+	var apiError *APIError
+	require.ErrorAs(t, err, &apiError)
+	assert.Equal(t, http.StatusBadRequest, apiError.Status)
+	assert.Equal(t, `{"error":"invalid request"}`, apiError.Body)
+	assert.Contains(t, output.String(), "msg=\"http request\"")
 }
 
 func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
@@ -57,12 +84,12 @@ func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
 	return &output
 }
 
-func newSuccessfulTestClient() *Client {
+func newTestClient(statusCode int, responseBody string) *Client {
 	c := New("https://api.example.com")
 	c.http = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			StatusCode: statusCode,
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
 			Header:     make(http.Header),
 		}, nil
 	})}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -30,6 +30,17 @@ func TestClientDo_LogsHTTPRequestsAtDebugLevel(t *testing.T) {
 	}
 }
 
+func TestClientDo_LogsConfiguredRequestAttributes(t *testing.T) {
+	output := captureLogs(t, slog.LevelDebug)
+	c := newTestClientWithOptions(http.StatusOK, `{}`, WithLogAttributes(slog.String("api", "beta")))
+
+	err := c.Do(context.Background(), "GET", "/nodes/test-id", nil, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, output.String(), "api=beta")
+	assert.Contains(t, output.String(), "path=/nodes/test-id")
+}
+
 func TestClientDo_DoesNotLogHTTPRequestsAtInfoLevel(t *testing.T) {
 	output := captureLogs(t, slog.LevelInfo)
 	c := newTestClient(http.StatusOK, `{}`)
@@ -85,7 +96,11 @@ func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
 }
 
 func newTestClient(statusCode int, responseBody string) *Client {
-	c := New("https://api.example.com")
+	return newTestClientWithOptions(statusCode, responseBody)
+}
+
+func newTestClientWithOptions(statusCode int, responseBody string, options ...Option) *Client {
+	c := New("https://api.example.com", options...)
 	c.http = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: statusCode,

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientDo_LogsHTTPRequestsAtDebugLevel(t *testing.T) {
+	output := captureLogs(t, slog.LevelDebug)
+	c := newSuccessfulTestClient()
+
+	for _, method := range []string{"GET", "POST", "DELETE"} {
+		output.Reset()
+
+		err := c.Do(context.Background(), method, "/nodes/test-id", nil, nil)
+
+		require.NoError(t, err)
+		assert.Contains(t, output.String(), "level=DEBUG")
+		assert.Contains(t, output.String(), "msg=\"http request\"")
+		assert.Contains(t, output.String(), "method="+method)
+		assert.Contains(t, output.String(), "path=/nodes/test-id")
+	}
+}
+
+func TestClientDo_DoesNotLogHTTPRequestsAtInfoLevel(t *testing.T) {
+	output := captureLogs(t, slog.LevelInfo)
+	c := newSuccessfulTestClient()
+
+	for _, method := range []string{"GET", "POST", "DELETE"} {
+		output.Reset()
+
+		err := c.Do(context.Background(), method, "/nodes/test-id", nil, nil)
+
+		require.NoError(t, err)
+		assert.NotContains(t, strings.TrimSpace(output.String()), "msg=\"http request\"")
+	}
+}
+
+func captureLogs(t *testing.T, level slog.Level) *bytes.Buffer {
+	t.Helper()
+
+	var output bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: level}))
+	previous := slog.Default()
+	slog.SetDefault(logger)
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	return &output
+}
+
+func newSuccessfulTestClient() *Client {
+	c := New("https://api.example.com")
+	c.http = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	return c
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/pkg/mcp/api_selection_test.go
+++ b/pkg/mcp/api_selection_test.go
@@ -1,0 +1,186 @@
+package mcp
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	mcptypes "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingClient struct {
+	calls atomic.Int64
+}
+
+func (client *recordingClient) record() {
+	client.calls.Add(1)
+}
+
+func (client *recordingClient) GetItem(context.Context, string) (*workflowy.Item, error) {
+	client.record()
+	return &workflowy.Item{ID: "item", Name: "Item"}, nil
+}
+
+func (client *recordingClient) ListChildren(context.Context, string) (*workflowy.ListChildrenResponse, error) {
+	client.record()
+	return &workflowy.ListChildrenResponse{}, nil
+}
+
+func (client *recordingClient) ListChildrenRecursive(context.Context, string) (*workflowy.ListChildrenResponse, error) {
+	client.record()
+	return &workflowy.ListChildrenResponse{}, nil
+}
+
+func (client *recordingClient) ListChildrenRecursiveWithDepth(context.Context, string, int) (*workflowy.ListChildrenResponse, error) {
+	client.record()
+	return &workflowy.ListChildrenResponse{Items: []*workflowy.Item{}}, nil
+}
+
+func (client *recordingClient) CreateNode(context.Context, *workflowy.CreateNodeRequest) (*workflowy.CreateNodeResponse, error) {
+	client.record()
+	return &workflowy.CreateNodeResponse{ItemID: "created"}, nil
+}
+
+func (client *recordingClient) UpdateNode(context.Context, string, *workflowy.UpdateNodeRequest) (*workflowy.UpdateNodeResponse, error) {
+	client.record()
+	return &workflowy.UpdateNodeResponse{Status: "ok"}, nil
+}
+
+func (client *recordingClient) MoveNode(context.Context, string, *workflowy.MoveNodeRequest) (*workflowy.MoveNodeResponse, error) {
+	client.record()
+	return &workflowy.MoveNodeResponse{Status: "ok"}, nil
+}
+
+func (client *recordingClient) CompleteNode(context.Context, string) (*workflowy.UpdateNodeResponse, error) {
+	client.record()
+	return &workflowy.UpdateNodeResponse{Status: "ok"}, nil
+}
+
+func (client *recordingClient) UncompleteNode(context.Context, string) (*workflowy.UpdateNodeResponse, error) {
+	client.record()
+	return &workflowy.UpdateNodeResponse{Status: "ok"}, nil
+}
+
+func (client *recordingClient) DeleteNode(context.Context, string) (*workflowy.UpdateNodeResponse, error) {
+	client.record()
+	return &workflowy.UpdateNodeResponse{Status: "ok"}, nil
+}
+
+func (client *recordingClient) ExportNodesWithCache(context.Context, bool) (*workflowy.ExportNodesResponse, error) {
+	client.record()
+	return &workflowy.ExportNodesResponse{}, nil
+}
+
+func (client *recordingClient) ListTargets(context.Context) (*workflowy.ListTargetsResponse, error) {
+	client.record()
+	return &workflowy.ListTargetsResponse{}, nil
+}
+
+func TestNetworkToolsExposeAndDispatchAPISelection(t *testing.T) {
+	productionClient := &recordingClient{}
+	betaClient := &recordingClient{}
+	builder := NewToolBuilder(
+		map[workflowy.APIDeployment]workflowy.Client{
+			workflowy.ProductionAPI: productionClient,
+			workflowy.BetaAPI:       betaClient,
+		},
+		workflowy.ProductionAPI,
+		"None",
+		"None",
+		"",
+		"",
+	)
+
+	tools, err := builder.BuildTools(allTools)
+	require.NoError(t, err)
+	require.Len(t, tools, len(allTools))
+
+	networkToolNames := map[string]struct{}{
+		ToolGet: {}, ToolList: {}, ToolSearch: {}, ToolTargets: {}, ToolID: {},
+		ToolCreate: {}, ToolUpdate: {}, ToolMove: {}, ToolDelete: {}, ToolComplete: {},
+		ToolUncomplete: {}, ToolReportCount: {}, ToolReportChildren: {}, ToolReportCreated: {},
+		ToolReportModified: {}, ToolReplace: {}, ToolTransform: {},
+	}
+	require.Len(t, networkToolNames, 17)
+
+	for _, tool := range tools {
+		_, isNetworkTool := networkToolNames[tool.Tool.Name]
+		property, hasAPIProperty := tool.Tool.InputSchema.Properties["api"]
+		if !isNetworkTool {
+			assert.Equal(t, ToolReportMirrors, tool.Tool.Name)
+			assert.False(t, hasAPIProperty)
+			continue
+		}
+
+		require.True(t, hasAPIProperty, "%s must expose api", tool.Tool.Name)
+		schema := property.(map[string]any)
+		assert.Equal(t, "string", schema["type"])
+		assert.ElementsMatch(t, []string{"production", "beta"}, schema["enum"])
+
+		result, handlerErr := tool.Handler(context.Background(), mcptypes.CallToolRequest{
+			Params: mcptypes.CallToolParams{
+				Name:      tool.Tool.Name,
+				Arguments: map[string]any{"api": "staging"},
+			},
+		})
+		require.NoError(t, handlerErr)
+		require.True(t, result.IsError, "%s must reject invalid api before its own handler", tool.Tool.Name)
+	}
+
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Zero(t, betaClient.calls.Load())
+}
+
+func TestAPISelectionDispatch(t *testing.T) {
+	tests := []struct {
+		name              string
+		defaultDeployment workflowy.APIDeployment
+		arguments         map[string]any
+		wantProduction    int64
+		wantBeta          int64
+	}{
+		{
+			name:              "explicit beta overrides production default",
+			defaultDeployment: workflowy.ProductionAPI,
+			arguments:         map[string]any{"api": "beta", "method": "get", "depth": float64(0)},
+			wantBeta:          1,
+		},
+		{
+			name:              "omission uses beta server default",
+			defaultDeployment: workflowy.BetaAPI,
+			arguments:         map[string]any{"method": "get", "depth": float64(0)},
+			wantBeta:          1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			productionClient := &recordingClient{}
+			betaClient := &recordingClient{}
+			builder := NewToolBuilder(
+				map[workflowy.APIDeployment]workflowy.Client{
+					workflowy.ProductionAPI: productionClient,
+					workflowy.BetaAPI:       betaClient,
+				},
+				test.defaultDeployment,
+				"None",
+				"None",
+				"",
+				"",
+			)
+			tools, err := builder.BuildTools([]string{ToolGet})
+			require.NoError(t, err)
+
+			result, handlerErr := tools[0].Handler(context.Background(), mcptypes.CallToolRequest{
+				Params: mcptypes.CallToolParams{Name: ToolGet, Arguments: test.arguments},
+			})
+			require.NoError(t, handlerErr)
+			require.False(t, result.IsError)
+			assert.Equal(t, test.wantProduction, productionClient.calls.Load())
+			assert.Equal(t, test.wantBeta, betaClient.calls.Load())
+		})
+	}
+}

--- a/pkg/mcp/api_selection_test.go
+++ b/pkg/mcp/api_selection_test.go
@@ -39,6 +39,11 @@ func (client *recordingClient) ListChildrenRecursiveWithDepth(context.Context, s
 	return &workflowy.ListChildrenResponse{Items: []*workflowy.Item{}}, nil
 }
 
+func (client *recordingClient) ListChildrenRecursiveWithOptions(context.Context, string, workflowy.RecursiveFetchOptions) (*workflowy.RecursiveFetchResult, error) {
+	client.record()
+	return &workflowy.RecursiveFetchResult{Response: &workflowy.ListChildrenResponse{Items: []*workflowy.Item{}}}, nil
+}
+
 func (client *recordingClient) CreateNode(context.Context, *workflowy.CreateNodeRequest) (*workflowy.CreateNodeResponse, error) {
 	client.record()
 	return &workflowy.CreateNodeResponse{ItemID: "created"}, nil

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -41,7 +41,10 @@ func RunServer(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("cannot load API key: %w", err)
 	}
 
-	client := workflowy.NewWorkflowyClient(option)
+	client, err := workflowy.NewWorkflowyClient(workflowy.ProductionAPI, option)
+	if err != nil {
+		return err
+	}
 
 	// Resolve write-root-id if provided (supports short IDs, target keys)
 	writeRootID := cfg.WriteRootID

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -9,11 +9,13 @@ import (
 
 	mcptypes "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
+	genericclient "github.com/mholzen/workflowy/pkg/client"
 	"github.com/mholzen/workflowy/pkg/workflowy"
 )
 
 // Config controls MCP server startup.
 type Config struct {
+	API               string
 	APIKeyFile        string
 	DefaultAPIKeyFile string
 	Expose            string
@@ -22,6 +24,44 @@ type Config struct {
 	ReadRootID        string
 	Method            string // "get", "export", "backup", or "" for auto
 	BackupFile        string // Path to backup file (for backup method)
+}
+
+type credentialResolver func(string, string) (genericclient.Option, error)
+
+type workflowyClientFactory func(workflowy.APIDeployment, ...genericclient.Option) (workflowy.Client, error)
+
+func createWorkflowyClient(deployment workflowy.APIDeployment, options ...genericclient.Option) (workflowy.Client, error) {
+	return workflowy.NewWorkflowyClient(deployment, options...)
+}
+
+func buildToolBuilder(cfg Config, resolveCredential credentialResolver, factory workflowyClientFactory) (ToolBuilder, error) {
+	defaultDeployment, err := workflowy.ParseAPIDeployment(cfg.API)
+	if err != nil {
+		return ToolBuilder{}, err
+	}
+
+	option, err := resolveCredential(cfg.APIKeyFile, cfg.DefaultAPIKeyFile)
+	if err != nil {
+		return ToolBuilder{}, fmt.Errorf("Cannot load Workflowy API key: %w", err)
+	}
+
+	clients := make(map[workflowy.APIDeployment]workflowy.Client, 2)
+	for _, deployment := range []workflowy.APIDeployment{workflowy.ProductionAPI, workflowy.BetaAPI} {
+		apiClient, err := factory(deployment, option)
+		if err != nil {
+			return ToolBuilder{}, fmt.Errorf("Cannot create %s Workflowy API client: %w", deployment, err)
+		}
+		clients[deployment] = apiClient
+	}
+
+	return NewToolBuilder(
+		clients,
+		defaultDeployment,
+		cfg.WriteRootID,
+		cfg.ReadRootID,
+		cfg.Method,
+		cfg.BackupFile,
+	), nil
 }
 
 // RunServer starts the MCP stdio server with the requested tool set.
@@ -36,39 +76,10 @@ func RunServer(ctx context.Context, cfg Config) error {
 		return err
 	}
 
-	option, err := workflowy.ResolveAPIKey(cfg.APIKeyFile, cfg.DefaultAPIKeyFile)
-	if err != nil {
-		return fmt.Errorf("cannot load API key: %w", err)
-	}
-
-	client, err := workflowy.NewWorkflowyClient(workflowy.ProductionAPI, option)
+	builder, err := buildToolBuilder(cfg, workflowy.ResolveAPIKey, createWorkflowyClient)
 	if err != nil {
 		return err
 	}
-
-	// Resolve write-root-id if provided (supports short IDs, target keys)
-	writeRootID := cfg.WriteRootID
-	if workflowy.IsWriteRestricted(writeRootID) {
-		resolvedID, err := workflowy.ResolveNodeIDToUUID(ctx, client, writeRootID)
-		if err != nil {
-			return fmt.Errorf("cannot resolve write-root-id: %w", err)
-		}
-		writeRootID = resolvedID
-		slog.Info("write restrictions enabled", "write_root_id", writeRootID)
-	}
-
-	// Resolve read-root-id if provided
-	readRootID := cfg.ReadRootID
-	if workflowy.IsRestricted(readRootID) {
-		resolvedID, err := workflowy.ResolveNodeIDToUUID(ctx, client, readRootID)
-		if err != nil {
-			return fmt.Errorf("cannot resolve read-root-id: %w", err)
-		}
-		readRootID = resolvedID
-		slog.Info("read restrictions enabled", "read_root_id", readRootID)
-	}
-
-	builder := NewToolBuilder(client, writeRootID, readRootID, cfg.Method, cfg.BackupFile)
 	serverTools, err := builder.BuildTools(toolsToEnable)
 	if err != nil {
 		return err

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"testing"
+
+	genericclient "github.com/mholzen/workflowy/pkg/client"
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildToolBuilderValidatesAPIBeforeCredentials(t *testing.T) {
+	credentialCalls := 0
+	factoryCalls := 0
+
+	_, err := buildToolBuilder(
+		Config{API: "staging"},
+		func(string, string) (genericclient.Option, error) {
+			credentialCalls++
+			return nil, nil
+		},
+		func(workflowy.APIDeployment, ...genericclient.Option) (workflowy.Client, error) {
+			factoryCalls++
+			return &recordingClient{}, nil
+		},
+	)
+
+	require.EqualError(t, err, `Cannot select Workflowy API "staging": expected "production" or "beta"`)
+	assert.Zero(t, credentialCalls)
+	assert.Zero(t, factoryCalls)
+}
+
+func TestBuildToolBuilderConstructsBothAPIsFromOneCredential(t *testing.T) {
+	credentialCalls := 0
+	optionApplications := 0
+	constructed := make([]workflowy.APIDeployment, 0, 2)
+
+	builder, err := buildToolBuilder(
+		Config{API: "beta"},
+		func(string, string) (genericclient.Option, error) {
+			credentialCalls++
+			return func(*genericclient.Client) {
+				optionApplications++
+			}, nil
+		},
+		func(deployment workflowy.APIDeployment, options ...genericclient.Option) (workflowy.Client, error) {
+			constructed = append(constructed, deployment)
+			genericclient.New("https://example.invalid", options...)
+			return &recordingClient{}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, workflowy.BetaAPI, builder.defaultDeployment)
+	assert.Equal(t, 1, credentialCalls)
+	assert.Equal(t, 2, optionApplications)
+	assert.ElementsMatch(t, []workflowy.APIDeployment{workflowy.ProductionAPI, workflowy.BetaAPI}, constructed)
+}

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -41,19 +41,38 @@ const (
 
 // ToolBuilder wires Workflowy operations into MCP tool handlers.
 type ToolBuilder struct {
-	client      workflowy.Client
-	writeRootID string
-	readRootID  string
-	method      string // "get", "export", "backup", or "" for auto-select based on depth
-	backupFile  string // Path to backup file (for backup method)
+	clients               map[workflowy.APIDeployment]workflowy.Client
+	defaultDeployment     workflowy.APIDeployment
+	deployment            workflowy.APIDeployment
+	client                workflowy.Client
+	rawWriteRootID        string
+	rawReadRootID         string
+	writeRootID           string
+	readRootID            string
+	method                string // "get", "export", "backup", or "" for auto-select based on depth
+	backupFile            string // Path to backup file (for backup method)
+	backupProvider        workflowy.BackupProvider
+	invocationTree        []*workflowy.Item
+	invocationSourceLabel string
 }
 
-// NewToolBuilder creates a builder bound to the provided Workflowy client.
-// If writeRootID is set, write operations are restricted to that node and its descendants.
-// If readRootID is set, all operations are restricted to that node and its descendants.
-// If method is set, it forces all operations to use that method (get, export, or backup).
-func NewToolBuilder(client workflowy.Client, writeRootID, readRootID, method, backupFile string) ToolBuilder {
-	return ToolBuilder{client: client, writeRootID: writeRootID, readRootID: readRootID, method: method, backupFile: backupFile}
+// NewToolBuilder creates a builder with per-deployment clients and unresolved restriction roots.
+func NewToolBuilder(
+	clients map[workflowy.APIDeployment]workflowy.Client,
+	defaultDeployment workflowy.APIDeployment,
+	writeRootID, readRootID, method, backupFile string,
+) ToolBuilder {
+	return ToolBuilder{
+		clients:           clients,
+		defaultDeployment: defaultDeployment,
+		rawWriteRootID:    writeRootID,
+		rawReadRootID:     readRootID,
+		writeRootID:       writeRootID,
+		readRootID:        readRootID,
+		method:            method,
+		backupFile:        backupFile,
+		backupProvider:    workflowy.DefaultBackupProvider,
+	}
 }
 
 // isRestricted returns true if write restrictions are in effect.
@@ -113,7 +132,7 @@ func (b ToolBuilder) validateReadTarget(ctx context.Context, targetID, operation
 	if !b.isReadRestricted() {
 		return nil
 	}
-	resolvedID, err := workflowy.ResolveNodeIDToUUID(ctx, b.client, targetID)
+	resolvedID, err := b.resolveNodeIDToUUID(ctx, targetID)
 	if err != nil {
 		slog.Warn("read access denied: target outside read-root scope",
 			"operation", operation, "target", targetID, "read_root", b.readRootID)
@@ -150,7 +169,7 @@ func (b ToolBuilder) validateWriteTarget(ctx context.Context, targetID, operatio
 	if !b.isRestricted() {
 		return nil
 	}
-	resolvedID, err := workflowy.ResolveNodeIDToUUID(ctx, b.client, targetID)
+	resolvedID, err := b.resolveNodeIDToUUID(ctx, targetID)
 	if err != nil {
 		slog.Warn("write access denied: target outside write-root scope",
 			"operation", operation, "target", targetID, "write_root", b.writeRootID)
@@ -174,7 +193,7 @@ func (b ToolBuilder) validateWriteParent(ctx context.Context, parentID, operatio
 			"write_root", b.writeRootID, "error", err)
 		return err
 	}
-	resolvedID, err := workflowy.ResolveNodeIDToUUID(ctx, b.client, parentID)
+	resolvedID, err := b.resolveNodeIDToUUID(ctx, parentID)
 	if err != nil {
 		slog.Warn("write parent access denied: target outside write-root scope",
 			"operation", operation, "parent", parentID, "write_root", b.writeRootID)
@@ -212,36 +231,204 @@ func (b ToolBuilder) writeRestrictionNote() string {
 
 // BuildTools constructs the requested tools in the order provided.
 func (b ToolBuilder) BuildTools(toolNames []string) ([]mcpserver.ServerTool, error) {
-	factories := map[string]func() mcpserver.ServerTool{
-		ToolGet:            b.buildGetTool,
-		ToolList:           b.buildListTool,
-		ToolSearch:         b.buildSearchTool,
-		ToolTargets:        b.buildTargetsTool,
-		ToolID:             b.buildIDTool,
-		ToolCreate:         b.buildCreateTool,
-		ToolUpdate:         b.buildUpdateTool,
-		ToolMove:           b.buildMoveTool,
-		ToolDelete:         b.buildDeleteTool,
-		ToolComplete:       b.buildCompleteTool,
-		ToolUncomplete:     b.buildUncompleteTool,
-		ToolReportCount:    b.buildReportCountTool,
-		ToolReportChildren: b.buildReportChildrenTool,
-		ToolReportCreated:  b.buildReportCreatedTool,
-		ToolReportModified: b.buildReportModifiedTool,
-		ToolReportMirrors:  b.buildReportMirrorsTool,
-		ToolReplace:        b.buildReplaceTool,
-		ToolTransform:      b.buildTransformTool,
-	}
-
 	var tools []mcpserver.ServerTool
 	for _, name := range toolNames {
-		factory, ok := factories[name]
+		factory, ok := toolFactories[name]
 		if !ok {
 			return nil, fmt.Errorf("unknown tool: %s", name)
 		}
-		tools = append(tools, factory())
+
+		tool := factory(b)
+		if _, ok := networkToolNames[name]; ok {
+			apiToolOption()(&tool.Tool)
+			tool.Handler = b.selectAPIHandler(factory)
+		} else if name == ToolReportMirrors {
+			tool.Handler = b.backupInvocationHandler(factory)
+		}
+		tools = append(tools, tool)
 	}
 	return tools, nil
+}
+
+type toolFactory func(ToolBuilder) mcpserver.ServerTool
+
+var toolFactories = map[string]toolFactory{
+	ToolGet:            ToolBuilder.buildGetTool,
+	ToolList:           ToolBuilder.buildListTool,
+	ToolSearch:         ToolBuilder.buildSearchTool,
+	ToolTargets:        ToolBuilder.buildTargetsTool,
+	ToolID:             ToolBuilder.buildIDTool,
+	ToolCreate:         ToolBuilder.buildCreateTool,
+	ToolUpdate:         ToolBuilder.buildUpdateTool,
+	ToolMove:           ToolBuilder.buildMoveTool,
+	ToolDelete:         ToolBuilder.buildDeleteTool,
+	ToolComplete:       ToolBuilder.buildCompleteTool,
+	ToolUncomplete:     ToolBuilder.buildUncompleteTool,
+	ToolReportCount:    ToolBuilder.buildReportCountTool,
+	ToolReportChildren: ToolBuilder.buildReportChildrenTool,
+	ToolReportCreated:  ToolBuilder.buildReportCreatedTool,
+	ToolReportModified: ToolBuilder.buildReportModifiedTool,
+	ToolReportMirrors:  ToolBuilder.buildReportMirrorsTool,
+	ToolReplace:        ToolBuilder.buildReplaceTool,
+	ToolTransform:      ToolBuilder.buildTransformTool,
+}
+
+var networkToolNames = map[string]struct{}{
+	ToolGet:            {},
+	ToolList:           {},
+	ToolSearch:         {},
+	ToolTargets:        {},
+	ToolID:             {},
+	ToolCreate:         {},
+	ToolUpdate:         {},
+	ToolMove:           {},
+	ToolDelete:         {},
+	ToolComplete:       {},
+	ToolUncomplete:     {},
+	ToolReportCount:    {},
+	ToolReportChildren: {},
+	ToolReportCreated:  {},
+	ToolReportModified: {},
+	ToolReplace:        {},
+	ToolTransform:      {},
+}
+
+func apiToolOption() mcptypes.ToolOption {
+	return mcptypes.WithString(
+		"api",
+		mcptypes.Description("Workflowy API deployment: production or beta"),
+		mcptypes.Enum(string(workflowy.ProductionAPI), string(workflowy.BetaAPI)),
+	)
+}
+
+func (b ToolBuilder) selectAPIHandler(factory toolFactory) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, request mcptypes.CallToolRequest) (*mcptypes.CallToolResult, error) {
+		deployment, err := workflowy.ParseAPIDeployment(request.GetString("api", string(b.defaultDeployment)))
+		if err != nil {
+			return mcptypes.NewToolResultError(err.Error()), nil
+		}
+
+		selectedClient, ok := b.clients[deployment]
+		if !ok {
+			return mcptypes.NewToolResultErrorf("Cannot select Workflowy API %q: client is not configured", deployment), nil
+		}
+
+		selectedBuilder := b
+		selectedBuilder.deployment = deployment
+		selectedBuilder.client = selectedClient
+		slog.Debug("selected Workflowy API", "api", deployment, "tool", request.Params.Name)
+
+		preparedBuilder, err := selectedBuilder.prepareInvocation(ctx, request, false)
+		if err != nil {
+			return mcptypes.NewToolResultError(err.Error()), nil
+		}
+		return factory(preparedBuilder).Handler(ctx, request)
+	}
+}
+
+func (b ToolBuilder) backupInvocationHandler(factory toolFactory) mcpserver.ToolHandlerFunc {
+	return func(ctx context.Context, request mcptypes.CallToolRequest) (*mcptypes.CallToolResult, error) {
+		preparedBuilder, err := b.prepareInvocation(ctx, request, true)
+		if err != nil {
+			return mcptypes.NewToolResultError(err.Error()), nil
+		}
+		return factory(preparedBuilder).Handler(ctx, request)
+	}
+}
+
+func (b ToolBuilder) prepareInvocation(ctx context.Context, request mcptypes.CallToolRequest, forceBackup bool) (ToolBuilder, error) {
+	useBackup := forceBackup || b.resolveMethod(request.GetString("method", "")) == "backup"
+	if useBackup {
+		items, source, err := b.readInvocationBackup()
+		if err != nil {
+			return ToolBuilder{}, err
+		}
+		b.invocationTree = items
+		b.invocationSourceLabel = source
+	}
+
+	var restrictionTree []*workflowy.Item
+	if b.invocationSourceLabel == "" && (workflowy.IsRestricted(b.rawWriteRootID) || workflowy.IsRestricted(b.rawReadRootID)) {
+		items, err := b.loadExportTree(ctx, false)
+		if err != nil {
+			return ToolBuilder{}, fmt.Errorf("Cannot load export tree for restriction roots using Workflowy API %q: %w", b.deployment, err)
+		}
+		restrictionTree = items
+	}
+
+	writeRootID, err := b.resolveRestrictionRoot(ctx, b.rawWriteRootID, "write", restrictionTree)
+	if err != nil {
+		return ToolBuilder{}, err
+	}
+	readRootID, err := b.resolveRestrictionRoot(ctx, b.rawReadRootID, "read", restrictionTree)
+	if err != nil {
+		return ToolBuilder{}, err
+	}
+
+	b.writeRootID = writeRootID
+	b.readRootID = readRootID
+	return b, nil
+}
+
+func (b ToolBuilder) readInvocationBackup() ([]*workflowy.Item, string, error) {
+	if b.backupFile != "" {
+		items, err := b.backupProvider.ReadBackupFile(b.backupFile)
+		if err != nil {
+			return nil, "", fmt.Errorf("Cannot read Workflowy backup %q: %w", b.backupFile, err)
+		}
+		return items, b.backupFile, nil
+	}
+
+	items, err := b.backupProvider.ReadLatestBackup()
+	if err != nil {
+		return nil, "", fmt.Errorf("Cannot read latest Workflowy backup: %w", err)
+	}
+	return items, "latest Workflowy backup", nil
+}
+
+func (b ToolBuilder) resolveRestrictionRoot(ctx context.Context, rawRootID, rootName string, restrictionTree []*workflowy.Item) (string, error) {
+	if !workflowy.IsRestricted(rawRootID) {
+		return rawRootID, nil
+	}
+
+	if b.invocationSourceLabel != "" {
+		resolvedID, err := workflowy.ResolveNodeIDFromTree(b.invocationTree, rawRootID)
+		if err == nil {
+			return resolvedID, nil
+		}
+		if !workflowy.IsShortID(rawRootID) && !workflowy.IsFullNodeID(rawRootID) {
+			return "", fmt.Errorf("Cannot resolve %s root %q from backup %q: target keys require an API; configure %s_root_id with a full or short node ID", rootName, rawRootID, b.invocationSourceLabel, rootName)
+		}
+		return "", fmt.Errorf("Cannot resolve %s root %q from backup %q: %w", rootName, rawRootID, b.invocationSourceLabel, err)
+	}
+
+	resolvedID, err := workflowy.ResolveNodeIDToUUID(ctx, b.client, rawRootID)
+	if err != nil {
+		return "", fmt.Errorf("Cannot resolve %s root %q using Workflowy API %q: %w", rootName, rawRootID, b.deployment, err)
+	}
+	if workflowy.FindItemByID(restrictionTree, resolvedID) == nil {
+		return "", fmt.Errorf("Cannot resolve %s root %q using Workflowy API %q: node was not found in export", rootName, rawRootID, b.deployment)
+	}
+	return resolvedID, nil
+}
+
+func (b ToolBuilder) resolveNodeID(ctx context.Context, rawID string) (string, error) {
+	if b.invocationSourceLabel == "" {
+		return workflowy.ResolveNodeID(ctx, b.client, rawID)
+	}
+
+	resolvedID, err := workflowy.ResolveNodeIDFromTree(b.invocationTree, rawID)
+	if err != nil {
+		return "", fmt.Errorf("Cannot resolve Workflowy node %q from backup %q: %w", rawID, b.invocationSourceLabel, err)
+	}
+	return resolvedID, nil
+}
+
+func (b ToolBuilder) resolveNodeIDToUUID(ctx context.Context, rawID string) (string, error) {
+	if b.invocationSourceLabel == "" {
+		return workflowy.ResolveNodeIDToUUID(ctx, b.client, rawID)
+	}
+	return b.resolveNodeID(ctx, rawID)
 }
 
 func (b ToolBuilder) buildGetTool() mcpserver.ServerTool {
@@ -310,9 +497,15 @@ func (b ToolBuilder) buildGetTool() mcpserver.ServerTool {
 				return mcptypes.NewToolResultError("cannot use ancestor options with method=get (requires full tree)"), nil
 			}
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
+			}
+			if toAncestor != "" {
+				toAncestor, err = b.resolveNodeID(ctx, toAncestor)
+				if err != nil {
+					return mcptypes.NewToolResultErrorFromErr("cannot resolve to_ancestor", err), nil
+				}
 			}
 
 			if err := b.validateReadTarget(ctx, itemID, "get", method); err != nil {
@@ -378,7 +571,7 @@ func (b ToolBuilder) buildListTool() mcpserver.ServerTool {
 			includeEmpty := req.GetBool("include_empty_names", false)
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -452,7 +645,7 @@ func (b ToolBuilder) buildSearchTool() mcpserver.ServerTool {
 			includeCompleted := req.GetBool("include_completed", false)
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -580,7 +773,7 @@ func (b ToolBuilder) buildIDTool() mcpserver.ServerTool {
 				return mcptypes.NewToolResultError("id is required"), nil
 			}
 
-			fullID, err := workflowy.ResolveNodeID(ctx, b.client, rawID)
+			fullID, err := b.resolveNodeID(ctx, rawID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -629,7 +822,7 @@ func (b ToolBuilder) buildCreateTool() mcpserver.ServerTool {
 			// Default parent to write-root-id or read-root-id if not specified
 			rawParentID := b.defaultCreateParent(req.GetString("parent_id", "None"))
 
-			parentID, err := workflowy.ResolveNodeID(ctx, b.client, rawParentID)
+			parentID, err := b.resolveNodeID(ctx, rawParentID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve parent ID", err), nil
 			}
@@ -694,7 +887,7 @@ func (b ToolBuilder) buildUpdateTool() mcpserver.ServerTool {
 			}
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -768,12 +961,12 @@ func (b ToolBuilder) buildMoveTool() mcpserver.ServerTool {
 			}
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
 
-			parentID, err := workflowy.ResolveNodeID(ctx, b.client, rawParentID)
+			parentID, err := b.resolveNodeID(ctx, rawParentID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve parent ID", err), nil
 			}
@@ -828,7 +1021,7 @@ func (b ToolBuilder) buildDeleteTool() mcpserver.ServerTool {
 			}
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -870,7 +1063,7 @@ func (b ToolBuilder) buildCompleteTool() mcpserver.ServerTool {
 			}
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -912,7 +1105,7 @@ func (b ToolBuilder) buildUncompleteTool() mcpserver.ServerTool {
 			}
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -960,7 +1153,7 @@ func (b ToolBuilder) buildReportCountTool() mcpserver.ServerTool {
 			threshold := req.GetFloat("threshold", 0.01)
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -1017,7 +1210,7 @@ func (b ToolBuilder) buildReportChildrenTool() mcpserver.ServerTool {
 			topN := req.GetInt("top_n", 20)
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -1071,7 +1264,7 @@ func (b ToolBuilder) buildReportCreatedTool() mcpserver.ServerTool {
 			topN := req.GetInt("top_n", 20)
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -1125,7 +1318,7 @@ func (b ToolBuilder) buildReportModifiedTool() mcpserver.ServerTool {
 			topN := req.GetInt("top_n", 20)
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -1167,12 +1360,16 @@ func (b ToolBuilder) buildReportMirrorsTool() mcpserver.ServerTool {
 				mcptypes.DefaultBool(false),
 			),
 		),
-		Handler: func(ctx context.Context, req mcptypes.CallToolRequest) (*mcptypes.CallToolResult, error) {
+		Handler: func(_ context.Context, req mcptypes.CallToolRequest) (*mcptypes.CallToolResult, error) {
 			topN := req.GetInt("top_n", 20)
 
-			items, err := workflowy.ReadLatestBackup()
-			if err != nil {
-				return mcptypes.NewToolResultErrorFromErr("cannot load backup file (mirror data requires backup)", err), nil
+			items := b.invocationTree
+			if b.isReadRestricted() {
+				root := workflowy.FindItemByID(items, b.readRootID)
+				if root == nil {
+					return mcptypes.NewToolResultErrorf("Cannot scope mirror report to read root %q in backup %q: node was not found", b.readRootID, b.invocationSourceLabel), nil
+				}
+				items = []*workflowy.Item{root}
 			}
 
 			infos := mirror.CollectMirrorInfos(items)
@@ -1246,7 +1443,7 @@ func (b ToolBuilder) buildReplaceTool() mcpserver.ServerTool {
 			dryRun := req.GetBool("dry_run", true)
 			method := req.GetString("method", "")
 
-			parentID, err := workflowy.ResolveNodeID(ctx, b.client, rawParentID)
+			parentID, err := b.resolveNodeID(ctx, rawParentID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve parent ID", err), nil
 			}
@@ -1372,7 +1569,7 @@ func (b ToolBuilder) buildTransformTool() mcpserver.ServerTool {
 			}
 			method := req.GetString("method", "")
 
-			itemID, err := workflowy.ResolveNodeID(ctx, b.client, rawItemID)
+			itemID, err := b.resolveNodeID(ctx, rawItemID)
 			if err != nil {
 				return mcptypes.NewToolResultErrorFromErr("cannot resolve ID", err), nil
 			}
@@ -1633,6 +1830,9 @@ func (b ToolBuilder) fetchItems(ctx context.Context, itemID string, depth int, m
 }
 
 func (b ToolBuilder) loadExportTree(ctx context.Context, force bool) ([]*workflowy.Item, error) {
+	if b.invocationSourceLabel != "" {
+		return b.invocationTree, nil
+	}
 	resp, err := b.client.ExportNodesWithCache(ctx, force)
 	if err != nil {
 		return nil, err
@@ -1642,10 +1842,13 @@ func (b ToolBuilder) loadExportTree(ctx context.Context, force bool) ([]*workflo
 }
 
 func (b ToolBuilder) loadBackupTree() ([]*workflowy.Item, error) {
-	if b.backupFile != "" {
-		return workflowy.ReadBackupFile(b.backupFile)
+	if b.invocationSourceLabel != "" {
+		return b.invocationTree, nil
 	}
-	return workflowy.ReadLatestBackup()
+	if b.backupFile != "" {
+		return b.backupProvider.ReadBackupFile(b.backupFile)
+	}
+	return b.backupProvider.ReadLatestBackup()
 }
 
 // resolveMethod returns the per-request method if provided, otherwise falls back to the builder's default.

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -1,0 +1,350 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcptypes "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mholzen/workflowy/pkg/workflowy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	backupRootID  = "11111111-1111-1111-1111-aaaaaaaaaaaa"
+	backupChildID = "22222222-2222-2222-2222-bbbbbbbbbbbb"
+)
+
+type countingBackupProvider struct {
+	items          []*workflowy.Item
+	fileReads      int
+	latestReads    int
+	lastBackupFile string
+}
+
+type treeClient struct {
+	recordingClient
+	nodes   []workflowy.ExportNode
+	targets map[string]string
+}
+
+func (client *treeClient) GetItem(_ context.Context, itemID string) (*workflowy.Item, error) {
+	client.record()
+	if resolvedID, ok := client.targets[itemID]; ok {
+		return &workflowy.Item{ID: resolvedID, Name: itemID}, nil
+	}
+	return &workflowy.Item{ID: itemID, Name: itemID}, nil
+}
+
+func (client *treeClient) ExportNodesWithCache(context.Context, bool) (*workflowy.ExportNodesResponse, error) {
+	client.record()
+	return &workflowy.ExportNodesResponse{Nodes: client.nodes}, nil
+}
+
+func (client *treeClient) ListTargets(context.Context) (*workflowy.ListTargetsResponse, error) {
+	client.record()
+	response := &workflowy.ListTargetsResponse{}
+	for key := range client.targets {
+		response.Targets = append(response.Targets, workflowy.Target{Key: key})
+	}
+	return response, nil
+}
+
+func (provider *countingBackupProvider) ReadBackupFile(filename string) ([]*workflowy.Item, error) {
+	provider.fileReads++
+	provider.lastBackupFile = filename
+	return provider.items, nil
+}
+
+func (provider *countingBackupProvider) ReadLatestBackup() ([]*workflowy.Item, error) {
+	provider.latestReads++
+	return provider.items, nil
+}
+
+func backupTestTree() []*workflowy.Item {
+	return []*workflowy.Item{
+		{
+			ID:   backupRootID,
+			Name: "Root branch",
+			Children: []*workflowy.Item{
+				{ID: backupChildID, Name: "Child"},
+			},
+		},
+	}
+}
+
+func newBackupTestBuilder(readRootID, writeRootID, backupFile string) (ToolBuilder, *recordingClient, *recordingClient, *countingBackupProvider) {
+	productionClient := &recordingClient{}
+	betaClient := &recordingClient{}
+	backupProvider := &countingBackupProvider{items: backupTestTree()}
+	builder := NewToolBuilder(
+		map[workflowy.APIDeployment]workflowy.Client{
+			workflowy.ProductionAPI: productionClient,
+			workflowy.BetaAPI:       betaClient,
+		},
+		workflowy.ProductionAPI,
+		writeRootID,
+		readRootID,
+		"",
+		backupFile,
+	)
+	builder.backupProvider = backupProvider
+	return builder, productionClient, betaClient, backupProvider
+}
+
+func callTool(t *testing.T, builder ToolBuilder, toolName string, arguments map[string]any) *mcptypes.CallToolResult {
+	t.Helper()
+	tools, err := builder.BuildTools([]string{toolName})
+	require.NoError(t, err)
+	result, err := tools[0].Handler(context.Background(), mcptypes.CallToolRequest{
+		Params: mcptypes.CallToolParams{Name: toolName, Arguments: arguments},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func toolResultText(t *testing.T, result *mcptypes.CallToolResult) string {
+	t.Helper()
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func TestBackupInvocationResolvesRootsAndIDsOffline(t *testing.T) {
+	builder, productionClient, betaClient, backupProvider := newBackupTestBuilder(backupRootID, "None", "fixture.backup")
+
+	result := callTool(t, builder, ToolGet, map[string]any{
+		"api":    "beta",
+		"method": "backup",
+		"id":     "bbbbbbbbbbbb",
+		"depth":  float64(0),
+	})
+
+	require.False(t, result.IsError, toolResultText(t, result))
+	assert.Equal(t, 1, backupProvider.fileReads)
+	assert.Equal(t, "fixture.backup", backupProvider.lastBackupFile)
+	assert.Zero(t, backupProvider.latestReads)
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Zero(t, betaClient.calls.Load())
+}
+
+func TestBackupValidationWritesThroughSelectedAPI(t *testing.T) {
+	builder, productionClient, betaClient, backupProvider := newBackupTestBuilder("None", "aaaaaaaaaaaa", "fixture.backup")
+
+	result := callTool(t, builder, ToolCreate, map[string]any{
+		"api":       "beta",
+		"method":    "backup",
+		"name":      "Created from backup validation",
+		"parent_id": "bbbbbbbbbbbb",
+	})
+
+	require.False(t, result.IsError, toolResultText(t, result))
+	assert.Equal(t, 1, backupProvider.fileReads)
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Equal(t, int64(1), betaClient.calls.Load())
+}
+
+func TestBackupRestrictionRootRejectsTargetKeyWithoutAPI(t *testing.T) {
+	tests := []struct {
+		name       string
+		backupFile string
+		wantLabel  string
+	}{
+		{name: "configured file", backupFile: "fixture.backup", wantLabel: "fixture.backup"},
+		{name: "latest backup", wantLabel: "latest Workflowy backup"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder, productionClient, betaClient, backupProvider := newBackupTestBuilder("inbox", "None", test.backupFile)
+			result := callTool(t, builder, ToolGet, map[string]any{"method": "backup", "depth": float64(0)})
+
+			require.True(t, result.IsError)
+			assert.Contains(t, toolResultText(t, result), `Cannot resolve read root \"inbox\" from backup \"`+test.wantLabel+`\": target keys require an API; configure read_root_id with a full or short node ID`)
+			assert.Equal(t, 1, backupProvider.fileReads+backupProvider.latestReads)
+			assert.Zero(t, productionClient.calls.Load())
+			assert.Zero(t, betaClient.calls.Load())
+		})
+	}
+}
+
+func TestMirrorReportUsesConfiguredBackupAndReadRoot(t *testing.T) {
+	insideMirrorID := "33333333-3333-3333-3333-cccccccccccc"
+	outsideRootID := "44444444-4444-4444-4444-dddddddddddd"
+	outsideMirrorID := "55555555-5555-5555-5555-eeeeeeeeeeee"
+
+	builder, productionClient, betaClient, backupProvider := newBackupTestBuilder("aaaaaaaaaaaa", "None", "mirrors.backup")
+	backupProvider.items = []*workflowy.Item{
+		{
+			ID: backupRootID, Name: "Included branch", Children: []*workflowy.Item{
+				{ID: insideMirrorID, Name: "Included mirror", Data: map[string]any{"mirror": map[string]any{"mirrorRootIds": map[string]any{"copy-a": true}}}},
+			},
+		},
+		{
+			ID: outsideRootID, Name: "Excluded branch", Children: []*workflowy.Item{
+				{ID: outsideMirrorID, Name: "Excluded mirror", Data: map[string]any{"mirror": map[string]any{"mirrorRootIds": map[string]any{"copy-b": true}}}},
+			},
+		},
+	}
+
+	result := callTool(t, builder, ToolReportMirrors, map[string]any{"top_n": float64(20)})
+
+	require.False(t, result.IsError, toolResultText(t, result))
+	resultText := toolResultText(t, result)
+	assert.True(t, strings.Contains(resultText, "Included mirror"))
+	assert.False(t, strings.Contains(resultText, "Excluded mirror"))
+	assert.Equal(t, 1, backupProvider.fileReads)
+	assert.Equal(t, "mirrors.backup", backupProvider.lastBackupFile)
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Zero(t, betaClient.calls.Load())
+}
+
+func TestMirrorReportAcceptsFullReadRoot(t *testing.T) {
+	builder, productionClient, betaClient, backupProvider := newBackupTestBuilder(backupRootID, "None", "mirrors.backup")
+
+	result := callTool(t, builder, ToolReportMirrors, map[string]any{})
+
+	require.False(t, result.IsError, toolResultText(t, result))
+	assert.Equal(t, 1, backupProvider.fileReads)
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Zero(t, betaClient.calls.Load())
+}
+
+func TestMirrorReportRejectsTargetKeyRootOffline(t *testing.T) {
+	builder, productionClient, betaClient, backupProvider := newBackupTestBuilder("inbox", "None", "mirrors.backup")
+
+	result := callTool(t, builder, ToolReportMirrors, map[string]any{})
+
+	require.True(t, result.IsError)
+	assert.Contains(t, toolResultText(t, result), `Cannot resolve read root \"inbox\" from backup \"mirrors.backup\": target keys require an API`)
+	assert.Equal(t, 1, backupProvider.fileReads)
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Zero(t, betaClient.calls.Load())
+}
+
+func TestNetworkResolutionUsesOnlySelectedDeployment(t *testing.T) {
+	parentID := backupRootID
+	productionClient := &treeClient{nodes: []workflowy.ExportNode{{ID: "99999999-9999-9999-9999-999999999999"}}}
+	betaClient := &treeClient{
+		targets: map[string]string{"inbox": backupRootID},
+		nodes: []workflowy.ExportNode{
+			{ID: backupRootID, Name: "Beta root"},
+			{ID: backupChildID, Name: "Beta child", ParentID: &parentID},
+		},
+	}
+	builder := NewToolBuilder(
+		map[workflowy.APIDeployment]workflowy.Client{
+			workflowy.ProductionAPI: productionClient,
+			workflowy.BetaAPI:       betaClient,
+		},
+		workflowy.ProductionAPI,
+		"None",
+		"inbox",
+		"",
+		"",
+	)
+
+	result := callTool(t, builder, ToolGet, map[string]any{
+		"api":    "beta",
+		"method": "export",
+		"id":     "bbbbbbbbbbbb",
+		"depth":  float64(0),
+	})
+
+	require.False(t, result.IsError, toolResultText(t, result))
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Positive(t, betaClient.calls.Load())
+}
+
+func TestFailedNetworkRootResolutionDoesNotLeakAcrossInvocations(t *testing.T) {
+	productionClient := &treeClient{nodes: []workflowy.ExportNode{{ID: backupRootID, Name: "Production root"}}}
+	betaClient := &treeClient{nodes: []workflowy.ExportNode{{ID: backupChildID, Name: "Beta node"}}}
+	builder := NewToolBuilder(
+		map[workflowy.APIDeployment]workflowy.Client{
+			workflowy.ProductionAPI: productionClient,
+			workflowy.BetaAPI:       betaClient,
+		},
+		workflowy.ProductionAPI,
+		"None",
+		"aaaaaaaaaaaa",
+		"",
+		"",
+	)
+
+	betaResult := callTool(t, builder, ToolGet, map[string]any{"api": "beta", "method": "export", "depth": float64(0)})
+	require.True(t, betaResult.IsError)
+	assert.Contains(t, toolResultText(t, betaResult), `Cannot resolve read root \"aaaaaaaaaaaa\" using Workflowy API \"beta\"`)
+
+	productionResult := callTool(t, builder, ToolGet, map[string]any{"api": "production", "method": "export", "depth": float64(0)})
+	require.False(t, productionResult.IsError, toolResultText(t, productionResult))
+	assert.Positive(t, productionClient.calls.Load())
+	assert.Positive(t, betaClient.calls.Load())
+}
+
+func TestNetworkRestrictionRootMustExistInSelectedExport(t *testing.T) {
+	productionClient := &treeClient{nodes: []workflowy.ExportNode{{ID: backupRootID, Name: "Production root"}}}
+	betaClient := &treeClient{nodes: []workflowy.ExportNode{{ID: backupChildID, Name: "Different beta node"}}}
+	builder := NewToolBuilder(
+		map[workflowy.APIDeployment]workflowy.Client{
+			workflowy.ProductionAPI: productionClient,
+			workflowy.BetaAPI:       betaClient,
+		},
+		workflowy.ProductionAPI,
+		"None",
+		backupRootID,
+		"",
+		"",
+	)
+
+	result := callTool(t, builder, ToolGet, map[string]any{"api": "beta", "method": "get", "depth": float64(0)})
+
+	require.True(t, result.IsError)
+	assert.Contains(t, toolResultText(t, result), `Cannot resolve read root \"`+backupRootID+`\" using Workflowy API \"beta\": node was not found in export`)
+	assert.Zero(t, productionClient.calls.Load())
+	assert.Positive(t, betaClient.calls.Load())
+}
+
+func TestBackupRequestIDsResolveOfflineAcrossHandlers(t *testing.T) {
+	tests := []struct {
+		name         string
+		toolName     string
+		arguments    map[string]any
+		wantAPICalls int64
+	}{
+		{name: "get id", toolName: ToolGet, arguments: map[string]any{"id": "bbbbbbbbbbbb", "depth": float64(0)}},
+		{name: "get to_ancestor", toolName: ToolGet, arguments: map[string]any{"id": "bbbbbbbbbbbb", "to_ancestor": "aaaaaaaaaaaa", "depth": float64(0)}},
+		{name: "list id", toolName: ToolList, arguments: map[string]any{"id": "aaaaaaaaaaaa", "depth": float64(1)}},
+		{name: "search id", toolName: ToolSearch, arguments: map[string]any{"id": "aaaaaaaaaaaa", "pattern": "Child"}},
+		{name: "id tool id", toolName: ToolID, arguments: map[string]any{"id": "bbbbbbbbbbbb"}},
+		{name: "create parent_id", toolName: ToolCreate, arguments: map[string]any{"name": "New", "parent_id": "aaaaaaaaaaaa"}, wantAPICalls: 1},
+		{name: "update id", toolName: ToolUpdate, arguments: map[string]any{"id": "bbbbbbbbbbbb", "name": "Updated"}, wantAPICalls: 1},
+		{name: "move id and parent_id", toolName: ToolMove, arguments: map[string]any{"id": "bbbbbbbbbbbb", "parent_id": "aaaaaaaaaaaa"}, wantAPICalls: 1},
+		{name: "delete id", toolName: ToolDelete, arguments: map[string]any{"id": "bbbbbbbbbbbb"}, wantAPICalls: 1},
+		{name: "complete id", toolName: ToolComplete, arguments: map[string]any{"id": "bbbbbbbbbbbb"}, wantAPICalls: 1},
+		{name: "uncomplete id", toolName: ToolUncomplete, arguments: map[string]any{"id": "bbbbbbbbbbbb"}, wantAPICalls: 1},
+		{name: "count report id", toolName: ToolReportCount, arguments: map[string]any{"id": "aaaaaaaaaaaa", "threshold": float64(0)}},
+		{name: "children report id", toolName: ToolReportChildren, arguments: map[string]any{"id": "aaaaaaaaaaaa", "top_n": float64(20)}},
+		{name: "created report id", toolName: ToolReportCreated, arguments: map[string]any{"id": "aaaaaaaaaaaa", "top_n": float64(20)}},
+		{name: "modified report id", toolName: ToolReportModified, arguments: map[string]any{"id": "aaaaaaaaaaaa", "top_n": float64(20)}},
+		{name: "replace parent_id", toolName: ToolReplace, arguments: map[string]any{"parent_id": "aaaaaaaaaaaa", "pattern": "Child", "substitution": "Task", "dry_run": true}},
+		{name: "transform id", toolName: ToolTransform, arguments: map[string]any{"id": "bbbbbbbbbbbb", "transform_name": "trim", "dry_run": true}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder, productionClient, betaClient, backupProvider := newBackupTestBuilder("None", "None", "fixture.backup")
+			builder.method = "backup"
+			test.arguments["api"] = "beta"
+
+			result := callTool(t, builder, test.toolName, test.arguments)
+
+			require.False(t, result.IsError, toolResultText(t, result))
+			assert.Equal(t, 1, backupProvider.fileReads)
+			assert.Zero(t, productionClient.calls.Load())
+			assert.Equal(t, test.wantAPICalls, betaClient.calls.Load())
+		})
+	}
+}

--- a/pkg/workflowy/api_deployment.go
+++ b/pkg/workflowy/api_deployment.go
@@ -1,0 +1,52 @@
+package workflowy
+
+import (
+	"fmt"
+
+	"github.com/mholzen/workflowy/pkg/cache"
+)
+
+type APIDeployment string
+
+const (
+	ProductionAPI APIDeployment = "production"
+	BetaAPI       APIDeployment = "beta"
+)
+
+func ParseAPIDeployment(raw string) (APIDeployment, error) {
+	if raw == "" {
+		return ProductionAPI, nil
+	}
+
+	deployment := APIDeployment(raw)
+	if _, err := deployment.BaseURL(); err != nil {
+		return "", err
+	}
+	return deployment, nil
+}
+
+func (deployment APIDeployment) BaseURL() (string, error) {
+	switch deployment {
+	case ProductionAPI:
+		return "https://workflowy.com/api/v1", nil
+	case BetaAPI:
+		return "https://beta.workflowy.com/api/v1", nil
+	default:
+		return "", invalidAPIDeploymentError(deployment)
+	}
+}
+
+func (deployment APIDeployment) exportCacheFile() (string, error) {
+	switch deployment {
+	case ProductionAPI:
+		return cache.DefaultCacheFile, nil
+	case BetaAPI:
+		return ".workflowy/export-cache-beta.json", nil
+	default:
+		return "", invalidAPIDeploymentError(deployment)
+	}
+}
+
+func invalidAPIDeploymentError(deployment APIDeployment) error {
+	return fmt.Errorf("Cannot select Workflowy API %q: expected %q or %q", deployment, ProductionAPI, BetaAPI)
+}

--- a/pkg/workflowy/api_deployment_test.go
+++ b/pkg/workflowy/api_deployment_test.go
@@ -1,0 +1,64 @@
+package workflowy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAPIDeployment(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    APIDeployment
+		wantErr string
+	}{
+		{name: "empty defaults to production", raw: "", want: ProductionAPI},
+		{name: "production", raw: "production", want: ProductionAPI},
+		{name: "beta", raw: "beta", want: BetaAPI},
+		{name: "invalid", raw: "prod", wantErr: `Cannot select Workflowy API "prod": expected "production" or "beta"`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseAPIDeployment(test.raw)
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestAPIDeploymentMappings(t *testing.T) {
+	productionURL, err := ProductionAPI.BaseURL()
+	require.NoError(t, err)
+	assert.Equal(t, "https://workflowy.com/api/v1", productionURL)
+
+	betaURL, err := BetaAPI.BaseURL()
+	require.NoError(t, err)
+	assert.Equal(t, "https://beta.workflowy.com/api/v1", betaURL)
+
+	productionCacheFile, err := ProductionAPI.exportCacheFile()
+	require.NoError(t, err)
+	assert.Equal(t, ".workflowy/export-cache.json", productionCacheFile)
+
+	betaCacheFile, err := BetaAPI.exportCacheFile()
+	require.NoError(t, err)
+	assert.Equal(t, ".workflowy/export-cache-beta.json", betaCacheFile)
+	assert.NotEqual(t, productionCacheFile, betaCacheFile)
+}
+
+func TestAPIDeploymentMappingsRejectInvalidValue(t *testing.T) {
+	invalid := APIDeployment("staging")
+
+	_, err := invalid.BaseURL()
+	assert.EqualError(t, err, `Cannot select Workflowy API "staging": expected "production" or "beta"`)
+
+	_, err = invalid.exportCacheFile()
+	assert.EqualError(t, err, `Cannot select Workflowy API "staging": expected "production" or "beta"`)
+}

--- a/pkg/workflowy/interfaces.go
+++ b/pkg/workflowy/interfaces.go
@@ -7,6 +7,7 @@ type Client interface {
 	ListChildren(ctx context.Context, itemID string) (*ListChildrenResponse, error)
 	ListChildrenRecursive(ctx context.Context, itemID string) (*ListChildrenResponse, error)
 	ListChildrenRecursiveWithDepth(ctx context.Context, itemID string, depth int) (*ListChildrenResponse, error)
+	ListChildrenRecursiveWithOptions(ctx context.Context, itemID string, options RecursiveFetchOptions) (*RecursiveFetchResult, error)
 	CreateNode(ctx context.Context, req *CreateNodeRequest) (*CreateNodeResponse, error)
 	UpdateNode(ctx context.Context, itemID string, req *UpdateNodeRequest) (*UpdateNodeResponse, error)
 	MoveNode(ctx context.Context, itemID string, req *MoveNodeRequest) (*MoveNodeResponse, error)

--- a/pkg/workflowy/mirror_reference.go
+++ b/pkg/workflowy/mirror_reference.go
@@ -1,0 +1,60 @@
+package workflowy
+
+import "fmt"
+
+type MirrorReferenceKind uint8
+
+const (
+	MirrorReferenceOrdinary MirrorReferenceKind = iota
+	MirrorReferenceWithOrigin
+	MirrorReferenceNullOrigin
+	MirrorReferenceMalformed
+)
+
+type MirrorReference struct {
+	Kind      MirrorReferenceKind
+	OriginID  string
+	Field     string
+	ValueType string
+}
+
+func MirrorReferenceFromItem(item *Item) MirrorReference {
+	if item == nil {
+		return MirrorReference{Kind: MirrorReferenceOrdinary}
+	}
+
+	mirror, ok := item.Data["mirror"].(map[string]interface{})
+	if !ok {
+		return MirrorReference{Kind: MirrorReferenceOrdinary}
+	}
+
+	if value, exists := mirror["origin_id"]; exists {
+		return mirrorReferenceFromValue("origin_id", value)
+	}
+	if value, exists := mirror["originalId"]; exists {
+		return mirrorReferenceFromValue("originalId", value)
+	}
+
+	return MirrorReference{Kind: MirrorReferenceOrdinary}
+}
+
+func mirrorReferenceFromValue(field string, value interface{}) MirrorReference {
+	if value == nil {
+		return MirrorReference{Kind: MirrorReferenceNullOrigin, Field: field}
+	}
+
+	originID, ok := value.(string)
+	if !ok {
+		return MirrorReference{
+			Kind:      MirrorReferenceMalformed,
+			Field:     field,
+			ValueType: fmt.Sprintf("%T", value),
+		}
+	}
+
+	return MirrorReference{Kind: MirrorReferenceWithOrigin, OriginID: originID, Field: field}
+}
+
+func (reference MirrorReference) IsMirror() bool {
+	return reference.Kind != MirrorReferenceOrdinary
+}

--- a/pkg/workflowy/mirror_reference_test.go
+++ b/pkg/workflowy/mirror_reference_test.go
@@ -1,0 +1,80 @@
+package workflowy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMirrorReferenceFromItem(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]interface{}
+		expected MirrorReference
+	}{
+		{
+			name:     "beta origin ID",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"origin_id": "origin-beta"}},
+			expected: MirrorReference{Kind: MirrorReferenceWithOrigin, OriginID: "origin-beta", Field: "origin_id"},
+		},
+		{
+			name:     "backup original ID",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"originalId": "origin-backup"}},
+			expected: MirrorReference{Kind: MirrorReferenceWithOrigin, OriginID: "origin-backup", Field: "originalId"},
+		},
+		{
+			name:     "null beta origin",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"origin_id": nil}},
+			expected: MirrorReference{Kind: MirrorReferenceNullOrigin, Field: "origin_id"},
+		},
+		{
+			name:     "null backup origin",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"originalId": nil}},
+			expected: MirrorReference{Kind: MirrorReferenceNullOrigin, Field: "originalId"},
+		},
+		{
+			name:     "malformed beta origin",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"origin_id": 42}},
+			expected: MirrorReference{Kind: MirrorReferenceMalformed, Field: "origin_id", ValueType: "int"},
+		},
+		{
+			name:     "malformed backup origin",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"originalId": true}},
+			expected: MirrorReference{Kind: MirrorReferenceMalformed, Field: "originalId", ValueType: "bool"},
+		},
+		{
+			name:     "origin mirror IDs only",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"mirror_ids": []interface{}{"mirror-a"}}},
+			expected: MirrorReference{Kind: MirrorReferenceOrdinary},
+		},
+		{
+			name:     "backup mirror root IDs only",
+			data:     map[string]interface{}{"mirror": map[string]interface{}{"mirrorRootIds": map[string]interface{}{"mirror-a": true}}},
+			expected: MirrorReference{Kind: MirrorReferenceOrdinary},
+		},
+		{
+			name:     "non-object mirror",
+			data:     map[string]interface{}{"mirror": "mirror-a"},
+			expected: MirrorReference{Kind: MirrorReferenceOrdinary},
+		},
+		{
+			name:     "missing data",
+			data:     nil,
+			expected: MirrorReference{Kind: MirrorReferenceOrdinary},
+		},
+		{
+			name:     "ordinary data",
+			data:     map[string]interface{}{"layoutMode": "bullets"},
+			expected: MirrorReference{Kind: MirrorReferenceOrdinary},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := MirrorReferenceFromItem(&Item{Data: test.data})
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.expected.Kind != MirrorReferenceOrdinary, actual.IsMirror())
+		})
+	}
+}

--- a/pkg/workflowy/recursive_fetch.go
+++ b/pkg/workflowy/recursive_fetch.go
@@ -1,0 +1,342 @@
+package workflowy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type RecursiveFetchOptions struct {
+	Depth          int
+	ResolveMirrors bool
+	Operation      string
+	RootItem       *Item
+}
+
+type RecursiveFetchResult struct {
+	Response *ListChildrenResponse
+	Summary  MirrorResolutionSummary
+}
+
+// ListChildrenRecursive retrieves children to the default depth. For a non-root
+// ID, this compatibility method retrieves the root item before listing children.
+func (wc *WorkflowyClient) ListChildrenRecursive(ctx context.Context, itemID string) (*ListChildrenResponse, error) {
+	return wc.ListChildrenRecursiveWithDepth(ctx, itemID, 5)
+}
+
+// ListChildrenRecursiveWithDepth retrieves children to the requested depth. For
+// a non-root ID, this compatibility method retrieves the root item first so its
+// mirror metadata and initial cycle path are available.
+func (wc *WorkflowyClient) ListChildrenRecursiveWithDepth(ctx context.Context, itemID string, depth int) (*ListChildrenResponse, error) {
+	result, err := wc.ListChildrenRecursiveWithOptions(ctx, itemID, RecursiveFetchOptions{
+		Depth:          depth,
+		ResolveMirrors: true,
+		Operation:      "get",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Response, nil
+}
+
+func (wc *WorkflowyClient) ListChildrenRecursiveWithOptions(
+	ctx context.Context,
+	itemID string,
+	options RecursiveFetchOptions,
+) (*RecursiveFetchResult, error) {
+	if options.RootItem != nil && options.RootItem.ID != itemID {
+		return nil, fmt.Errorf(
+			"Cannot recursively fetch Workflowy node %q: supplied root item has ID %q",
+			itemID,
+			options.RootItem.ID,
+		)
+	}
+
+	tracker := newRecursiveFetchTracker(wc.recursiveSourceLabel(), itemID, options)
+	defer tracker.finish()
+	if options.Depth <= 0 {
+		return &RecursiveFetchResult{Response: &ListChildrenResponse{}, Summary: tracker.summary}, nil
+	}
+
+	if itemID == "None" {
+		response, err := wc.ListChildren(ctx, itemID)
+		if err != nil {
+			return nil, recursiveFetchError(itemID, options.Operation, tracker.source, err)
+		}
+		for _, item := range response.Items {
+			occurrencePath := []string{item.ID}
+			activeIDs := []string{item.ID}
+			tracker.observe(occurrencePath)
+			tracker.retain(occurrencePath)
+			if options.Depth > 1 {
+				if err := wc.populateRecursiveChildren(ctx, item, options.Depth-1, options, occurrencePath, activeIDs, tracker); err != nil {
+					return nil, err
+				}
+			}
+		}
+		return &RecursiveFetchResult{Response: response, Summary: tracker.summary}, nil
+	}
+
+	root := options.RootItem
+	if root == nil {
+		var err error
+		root, err = wc.GetItem(ctx, itemID)
+		if err != nil {
+			return nil, recursiveFetchError(itemID, options.Operation, tracker.source, err)
+		}
+		if root.ID != itemID {
+			return nil, fmt.Errorf(
+				"Cannot recursively fetch Workflowy node %q: API returned root item with ID %q",
+				itemID,
+				root.ID,
+			)
+		}
+	}
+	occurrencePath := []string{root.ID}
+	activeIDs := []string{root.ID}
+	tracker.observe(occurrencePath)
+	response, err := wc.fetchRecursiveChildren(ctx, root, options.Depth, options, occurrencePath, activeIDs, tracker)
+	if err != nil {
+		return nil, err
+	}
+	return &RecursiveFetchResult{Response: response, Summary: tracker.summary}, nil
+}
+
+func (wc *WorkflowyClient) populateRecursiveChildren(
+	ctx context.Context,
+	item *Item,
+	depth int,
+	options RecursiveFetchOptions,
+	occurrencePath []string,
+	activeIDs []string,
+	tracker *recursiveFetchTracker,
+) error {
+	response, err := wc.fetchRecursiveChildren(ctx, item, depth, options, occurrencePath, activeIDs, tracker)
+	if err != nil {
+		return err
+	}
+	item.Children = response.Items
+	return nil
+}
+
+func (wc *WorkflowyClient) fetchRecursiveChildren(
+	ctx context.Context,
+	item *Item,
+	depth int,
+	options RecursiveFetchOptions,
+	occurrencePath []string,
+	activeIDs []string,
+	tracker *recursiveFetchTracker,
+) (*ListChildrenResponse, error) {
+	if depth <= 0 {
+		return &ListChildrenResponse{}, nil
+	}
+
+	reference := MirrorReferenceFromItem(item)
+	if reference.IsMirror() && !options.ResolveMirrors {
+		return &ListChildrenResponse{}, nil
+	}
+	if options.ResolveMirrors {
+		switch reference.Kind {
+		case MirrorReferenceMalformed:
+			tracker.recordMalformed(item, reference, occurrencePath)
+		case MirrorReferenceWithOrigin:
+			if containsString(activeIDs, reference.OriginID) {
+				tracker.recordCycle(item, reference, occurrencePath)
+				return &ListChildrenResponse{}, nil
+			}
+			tracker.recordResolved(occurrencePath)
+			activeIDs = append(activeIDs, reference.OriginID)
+		}
+	}
+
+	response, err := wc.ListChildren(ctx, item.ID)
+	if err != nil {
+		return nil, recursiveFetchError(item.ID, options.Operation, tracker.source, err)
+	}
+	for _, child := range response.Items {
+		childOccurrencePath := append(occurrencePath, child.ID)
+		childActiveIDs := append(activeIDs, child.ID)
+		tracker.observe(childOccurrencePath)
+		tracker.retain(childOccurrencePath)
+		if depth > 1 {
+			if err := wc.populateRecursiveChildren(ctx, child, depth-1, options, childOccurrencePath, childActiveIDs, tracker); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return response, nil
+}
+
+func recursiveFetchError(itemID, operation, source string, err error) error {
+	return fmt.Errorf(
+		"Cannot recursively fetch Workflowy node %q during %s from %s: %w",
+		itemID,
+		operation,
+		source,
+		err,
+	)
+}
+
+func (wc *WorkflowyClient) recursiveSourceLabel() string {
+	if wc.deployment == "" {
+		return "Workflowy API"
+	}
+	return fmt.Sprintf("Workflowy %s API", wc.deployment)
+}
+
+type recursiveFetchTracker struct {
+	logger              *slog.Logger
+	source              string
+	targetID            string
+	options             RecursiveFetchOptions
+	startedAt           time.Time
+	debugEnabled        bool
+	summary             MirrorResolutionSummary
+	cycles              map[string]*cycleDiagnostic
+	visited             map[string]struct{}
+	retained            map[string]struct{}
+	visitedOccurrences  int
+	retainedOccurrences int
+	currentPathDepth    int
+	maximumPathDepth    int
+	nextProgress        int
+}
+
+func newRecursiveFetchTracker(source, targetID string, options RecursiveFetchOptions) *recursiveFetchTracker {
+	logger := slog.Default()
+	tracker := &recursiveFetchTracker{
+		logger:       logger,
+		source:       source,
+		targetID:     targetID,
+		options:      options,
+		startedAt:    time.Now(),
+		debugEnabled: logger.Enabled(context.Background(), slog.LevelDebug),
+		cycles:       make(map[string]*cycleDiagnostic),
+		visited:      make(map[string]struct{}),
+		retained:     make(map[string]struct{}),
+		nextProgress: traversalProgressStart,
+	}
+	if tracker.debugEnabled {
+		tracker.logDebug("Workflowy recursive mirror traversal started")
+	}
+	return tracker
+}
+
+func (tracker *recursiveFetchTracker) observe(path []string) {
+	identity := strings.Join(path, "/")
+	if _, exists := tracker.visited[identity]; exists {
+		return
+	}
+	tracker.visited[identity] = struct{}{}
+	tracker.visitedOccurrences++
+	tracker.currentPathDepth = len(path)
+	if len(path) > tracker.maximumPathDepth {
+		tracker.maximumPathDepth = len(path)
+	}
+	if tracker.debugEnabled && tracker.visitedOccurrences >= tracker.nextProgress {
+		tracker.logDebug("Workflowy recursive mirror traversal progress")
+		tracker.nextProgress *= 2
+	}
+}
+
+func (tracker *recursiveFetchTracker) retain(path []string) {
+	identity := strings.Join(path, "/")
+	if _, exists := tracker.retained[identity]; exists {
+		return
+	}
+	tracker.retained[identity] = struct{}{}
+	tracker.retainedOccurrences++
+}
+
+func (tracker *recursiveFetchTracker) recordResolved(path []string) {
+	tracker.summary.Resolved++
+	tracker.observe(path)
+}
+
+func (tracker *recursiveFetchTracker) recordMalformed(item *Item, reference MirrorReference, path []string) {
+	tracker.summary.MalformedMetadata++
+	tracker.logger.Warn(
+		"Workflowy mirror metadata is malformed; using API children",
+		"mirror_id", item.ID,
+		"field", reference.Field,
+		"value_type", reference.ValueType,
+		"path", strings.Join(path, "/"),
+		"source", tracker.source,
+		"operation", tracker.options.Operation,
+	)
+}
+
+func (tracker *recursiveFetchTracker) recordCycle(item *Item, reference MirrorReference, path []string) {
+	tracker.summary.Cycles++
+	key := item.ID + "\x00" + reference.OriginID
+	diagnostic := tracker.cycles[key]
+	if diagnostic == nil {
+		diagnostic = &cycleDiagnostic{mirrorID: item.ID, originID: reference.OriginID, firstPath: strings.Join(path, "/")}
+		tracker.cycles[key] = diagnostic
+	}
+	diagnostic.occurrences++
+}
+
+func (tracker *recursiveFetchTracker) finish() {
+	for _, diagnostic := range tracker.cycles {
+		tracker.logger.Warn(
+			"Workflowy mirror cycle stopped",
+			"mirror_id", diagnostic.mirrorID,
+			"origin_id", diagnostic.originID,
+			"path", diagnostic.firstPath,
+			"occurrences", diagnostic.occurrences,
+			"source", tracker.source,
+			"operation", tracker.options.Operation,
+		)
+	}
+	if warning := tracker.summary.ThresholdWarning(tracker.options.Operation, tracker.source); warning != "" {
+		tracker.logger.Warn(warning)
+	}
+	attributes := tracker.attributes()
+	attributes = append(attributes,
+		"resolved", tracker.summary.Resolved,
+		"missing_origin", tracker.summary.MissingOrigin,
+		"malformed_metadata", tracker.summary.MalformedMetadata,
+		"cycles", tracker.summary.Cycles,
+		"attempts", tracker.summary.Attempts(),
+		"failures", tracker.summary.Failures(),
+	)
+	if tracker.debugEnabled {
+		attributes = append(attributes, recursiveMemoryAttributes()...)
+	}
+	tracker.logger.Info("Workflowy recursive mirror traversal completed", attributes...)
+}
+
+func (tracker *recursiveFetchTracker) logDebug(message string) {
+	attributes := append(tracker.attributes(), recursiveMemoryAttributes()...)
+	tracker.logger.Debug(message, attributes...)
+}
+
+func (tracker *recursiveFetchTracker) attributes() []interface{} {
+	return []interface{}{
+		"operation", tracker.options.Operation,
+		"source", tracker.source,
+		"scope", tracker.targetID,
+		"target", tracker.targetID,
+		"requested_depth", tracker.options.Depth,
+		"effective_depth", tracker.options.Depth,
+		"visited_occurrences", tracker.visitedOccurrences,
+		"retained_occurrences", tracker.retainedOccurrences,
+		"current_path_depth", tracker.currentPathDepth,
+		"maximum_path_depth", tracker.maximumPathDepth,
+		"elapsed", time.Since(tracker.startedAt),
+	}
+}
+
+func recursiveMemoryAttributes() []interface{} {
+	stats := readTraversalMemoryStats()
+	return []interface{}{
+		"heap_bytes", stats.HeapBytes,
+		"heap_objects", stats.HeapObjects,
+		"total_allocated_bytes", stats.TotalAllocatedBytes,
+		"gc_count", stats.GarbageCollections,
+	}
+}

--- a/pkg/workflowy/recursive_fetch.go
+++ b/pkg/workflowy/recursive_fetch.go
@@ -56,11 +56,11 @@ func (wc *WorkflowyClient) ListChildrenRecursiveWithOptions(
 
 	tracker := newRecursiveFetchTracker(wc.recursiveSourceLabel(), itemID, options)
 	defer tracker.finish()
-	if options.Depth <= 0 {
-		return &RecursiveFetchResult{Response: &ListChildrenResponse{}, Summary: tracker.summary}, nil
-	}
 
 	if itemID == "None" {
+		if options.Depth <= 0 {
+			return &RecursiveFetchResult{Response: &ListChildrenResponse{}, Summary: tracker.summary}, nil
+		}
 		response, err := wc.ListChildren(ctx, itemID)
 		if err != nil {
 			return nil, recursiveFetchError(itemID, options.Operation, tracker.source, err)
@@ -69,7 +69,7 @@ func (wc *WorkflowyClient) ListChildrenRecursiveWithOptions(
 			occurrencePath := []string{item.ID}
 			activeIDs := []string{item.ID}
 			tracker.observe(occurrencePath)
-			tracker.retain(occurrencePath)
+			tracker.retain()
 			if options.Depth > 1 {
 				if err := wc.populateRecursiveChildren(ctx, item, options.Depth-1, options, occurrencePath, activeIDs, tracker); err != nil {
 					return nil, err
@@ -97,6 +97,9 @@ func (wc *WorkflowyClient) ListChildrenRecursiveWithOptions(
 	occurrencePath := []string{root.ID}
 	activeIDs := []string{root.ID}
 	tracker.observe(occurrencePath)
+	if options.Depth <= 0 {
+		return &RecursiveFetchResult{Response: &ListChildrenResponse{}, Summary: tracker.summary}, nil
+	}
 	response, err := wc.fetchRecursiveChildren(ctx, root, options.Depth, options, occurrencePath, activeIDs, tracker)
 	if err != nil {
 		return nil, err
@@ -143,11 +146,15 @@ func (wc *WorkflowyClient) fetchRecursiveChildren(
 		case MirrorReferenceMalformed:
 			tracker.recordMalformed(item, reference, occurrencePath)
 		case MirrorReferenceWithOrigin:
+			if reference.OriginID == "" {
+				tracker.recordMissing(item, occurrencePath)
+				break
+			}
 			if containsString(activeIDs, reference.OriginID) {
 				tracker.recordCycle(item, reference, occurrencePath)
 				return &ListChildrenResponse{}, nil
 			}
-			tracker.recordResolved(occurrencePath)
+			tracker.recordResolved()
 			activeIDs = append(activeIDs, reference.OriginID)
 		}
 	}
@@ -160,7 +167,7 @@ func (wc *WorkflowyClient) fetchRecursiveChildren(
 		childOccurrencePath := append(occurrencePath, child.ID)
 		childActiveIDs := append(activeIDs, child.ID)
 		tracker.observe(childOccurrencePath)
-		tracker.retain(childOccurrencePath)
+		tracker.retain()
 		if depth > 1 {
 			if err := wc.populateRecursiveChildren(ctx, child, depth-1, options, childOccurrencePath, childActiveIDs, tracker); err != nil {
 				return nil, err
@@ -196,8 +203,6 @@ type recursiveFetchTracker struct {
 	debugEnabled        bool
 	summary             MirrorResolutionSummary
 	cycles              map[string]*cycleDiagnostic
-	visited             map[string]struct{}
-	retained            map[string]struct{}
 	visitedOccurrences  int
 	retainedOccurrences int
 	currentPathDepth    int
@@ -215,8 +220,6 @@ func newRecursiveFetchTracker(source, targetID string, options RecursiveFetchOpt
 		startedAt:    time.Now(),
 		debugEnabled: logger.Enabled(context.Background(), slog.LevelDebug),
 		cycles:       make(map[string]*cycleDiagnostic),
-		visited:      make(map[string]struct{}),
-		retained:     make(map[string]struct{}),
 		nextProgress: traversalProgressStart,
 	}
 	if tracker.debugEnabled {
@@ -226,11 +229,6 @@ func newRecursiveFetchTracker(source, targetID string, options RecursiveFetchOpt
 }
 
 func (tracker *recursiveFetchTracker) observe(path []string) {
-	identity := strings.Join(path, "/")
-	if _, exists := tracker.visited[identity]; exists {
-		return
-	}
-	tracker.visited[identity] = struct{}{}
 	tracker.visitedOccurrences++
 	tracker.currentPathDepth = len(path)
 	if len(path) > tracker.maximumPathDepth {
@@ -242,18 +240,24 @@ func (tracker *recursiveFetchTracker) observe(path []string) {
 	}
 }
 
-func (tracker *recursiveFetchTracker) retain(path []string) {
-	identity := strings.Join(path, "/")
-	if _, exists := tracker.retained[identity]; exists {
-		return
-	}
-	tracker.retained[identity] = struct{}{}
+func (tracker *recursiveFetchTracker) retain() {
 	tracker.retainedOccurrences++
 }
 
-func (tracker *recursiveFetchTracker) recordResolved(path []string) {
+func (tracker *recursiveFetchTracker) recordResolved() {
 	tracker.summary.Resolved++
-	tracker.observe(path)
+}
+
+func (tracker *recursiveFetchTracker) recordMissing(item *Item, path []string) {
+	tracker.summary.MissingOrigin++
+	tracker.logger.Warn(
+		"Workflowy mirror origin is empty; using API children",
+		"mirror_id", item.ID,
+		"origin_id", "",
+		"path", strings.Join(path, "/"),
+		"source", tracker.source,
+		"operation", tracker.options.Operation,
+	)
 }
 
 func (tracker *recursiveFetchTracker) recordMalformed(item *Item, reference MirrorReference, path []string) {

--- a/pkg/workflowy/recursive_fetch_test.go
+++ b/pkg/workflowy/recursive_fetch_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -47,6 +48,23 @@ func TestRecursiveFetchNilRootRetrievesMirrorBeforeDisabledTraversal(t *testing.
 	require.NoError(t, err)
 	assert.Empty(t, result.Response.Items)
 	assert.Equal(t, []string{"/nodes/mirror"}, requests.snapshot())
+}
+
+func TestRecursiveFetchNilRootRetrievesNodeAtDepthZero(t *testing.T) {
+	root := testItem("root")
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		require.Equal(t, "/nodes/root", request.URL.RequestURI())
+		return GetItemResponse{Node: *root}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), root.ID, RecursiveFetchOptions{
+		Depth:          0,
+		ResolveMirrors: true,
+		Operation:      "get",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Response.Items)
+	assert.Equal(t, []string{"/nodes/root"}, requests.snapshot())
 }
 
 func TestRecursiveFetchRejectsMismatchedRootItem(t *testing.T) {
@@ -188,6 +206,24 @@ func TestRecursiveFetchUsesMetadataForBothDeployments(t *testing.T) {
 	}
 }
 
+func TestRecursiveFetchTreatsEmptyOriginAsMissing(t *testing.T) {
+	mirror := testMirror("mirror", "")
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		require.Equal(t, "/nodes?parent_id=mirror", request.URL.RequestURI())
+		return ListChildrenResponse{}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), mirror.ID, RecursiveFetchOptions{
+		Depth:          1,
+		ResolveMirrors: true,
+		Operation:      "get",
+		RootItem:       mirror,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Summary.MissingOrigin)
+	assert.Equal(t, []string{"/nodes?parent_id=mirror"}, requests.snapshot())
+}
+
 func TestRecursiveFetchReturnsResolutionSummaryAndLogsOneTraversalSummary(t *testing.T) {
 	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
 	success := testMirror("success", "origin")
@@ -213,11 +249,39 @@ func TestRecursiveFetchReturnsResolutionSummaryAndLogsOneTraversalSummary(t *tes
 	})
 	require.NoError(t, err)
 	assert.Equal(t, MirrorResolutionSummary{Resolved: 1, MalformedMetadata: 1}, result.Summary)
-	assert.Len(t, logs.withMessage("Workflowy recursive mirror traversal completed"), 1)
+	completion := logs.requireOne(t, "Workflowy recursive mirror traversal completed")
+	assert.Equal(t, int64(2), completion.attrs["visited_occurrences"])
+	assert.Equal(t, int64(2), completion.attrs["retained_occurrences"])
+	assert.Equal(t, int64(1), completion.attrs["resolved"])
+	assert.Equal(t, int64(1), completion.attrs["malformed_metadata"])
 	malformedLog := logs.requireOne(t, "Workflowy mirror metadata is malformed; using API children")
 	assert.Equal(t, "malformed", malformedLog.attrs["mirror_id"])
 	assert.Equal(t, "list", malformedLog.attrs["operation"])
 	assert.Len(t, logs.withMessage(result.Summary.ThresholdWarning("list", "Workflowy API")), 1)
+}
+
+func TestRecursiveFetchDoesNotWarnBelowFailureThreshold(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	items := []*Item{
+		testMirror("success-one", "origin-one"),
+		testMirror("success-two", "origin-two"),
+		{ID: "malformed", Data: map[string]interface{}{"mirror": map[string]interface{}{"origin_id": 3}}},
+	}
+	client, _ := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		if request.URL.Query().Get("parent_id") == "None" {
+			return ListChildrenResponse{Items: items}
+		}
+		return ListChildrenResponse{}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), "None", RecursiveFetchOptions{
+		Depth:          2,
+		ResolveMirrors: true,
+		Operation:      "list",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, MirrorResolutionSummary{Resolved: 2, MalformedMetadata: 1}, result.Summary)
+	assert.Empty(t, logs.withMessagePrefix("Mirror resolution failures reached"))
 }
 
 func TestRecursiveFetchLogsContextualCycle(t *testing.T) {
@@ -238,6 +302,41 @@ func TestRecursiveFetchLogsContextualCycle(t *testing.T) {
 	assert.Equal(t, "cycle", cycleLog.attrs["mirror_id"])
 	assert.Equal(t, "origin", cycleLog.attrs["origin_id"])
 	assert.Equal(t, "entry/cycle", cycleLog.attrs["path"])
+}
+
+func TestRecursiveFetchWrapsNetworkErrorsWithContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		rootItem *Item
+		failPath string
+	}{
+		{name: "root retrieval", failPath: "/nodes/root"},
+		{name: "child listing", rootItem: testItem("root"), failPath: "/nodes?parent_id=root"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				assert.Equal(t, test.failPath, request.URL.RequestURI())
+				http.Error(writer, "upstream failure", http.StatusBadGateway)
+			}))
+			defer server.Close()
+			client := &WorkflowyClient{Client: workflowyclient.New(server.URL)}
+
+			result, err := client.ListChildrenRecursiveWithOptions(context.Background(), "root", RecursiveFetchOptions{
+				Depth:          1,
+				ResolveMirrors: true,
+				Operation:      "get",
+				RootItem:       test.rootItem,
+			})
+
+			assert.Nil(t, result)
+			require.Error(t, err)
+			assert.True(t, strings.HasPrefix(err.Error(), `Cannot recursively fetch Workflowy node "root"`))
+			assert.ErrorContains(t, err, "Workflowy API")
+			assert.ErrorContains(t, err, "502")
+		})
+	}
 }
 
 type synchronizedRequests struct {

--- a/pkg/workflowy/recursive_fetch_test.go
+++ b/pkg/workflowy/recursive_fetch_test.go
@@ -1,0 +1,273 @@
+package workflowy
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	workflowyclient "github.com/mholzen/workflowy/pkg/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecursiveFetchDisabledDoesNotListMirrorChildren(t *testing.T) {
+	mirror := testMirror("mirror", "origin")
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		t.Fatalf("unexpected HTTP request: %s", request.URL.RequestURI())
+		return nil
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), mirror.ID, RecursiveFetchOptions{
+		Depth:          3,
+		ResolveMirrors: false,
+		Operation:      "get",
+		RootItem:       mirror,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Response.Items)
+	assert.Empty(t, requests.snapshot())
+}
+
+func TestRecursiveFetchNilRootRetrievesMirrorBeforeDisabledTraversal(t *testing.T) {
+	mirror := testMirror("mirror", "origin")
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		require.Equal(t, "/nodes/mirror", request.URL.RequestURI())
+		return GetItemResponse{Node: *mirror}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), mirror.ID, RecursiveFetchOptions{
+		Depth:          3,
+		ResolveMirrors: false,
+		Operation:      "get",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Response.Items)
+	assert.Equal(t, []string{"/nodes/mirror"}, requests.snapshot())
+}
+
+func TestRecursiveFetchRejectsMismatchedRootItem(t *testing.T) {
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		t.Fatalf("unexpected HTTP request: %s", request.URL.RequestURI())
+		return nil
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), "requested", RecursiveFetchOptions{
+		Depth:          2,
+		ResolveMirrors: true,
+		Operation:      "get",
+		RootItem:       testItem("supplied"),
+	})
+
+	assert.Nil(t, result)
+	require.EqualError(t, err, `Cannot recursively fetch Workflowy node "requested": supplied root item has ID "supplied"`)
+	assert.Empty(t, requests.snapshot())
+}
+
+func TestRecursiveFetchDisabledStillListsOrdinaryChildren(t *testing.T) {
+	root := testItem("root")
+	mirror := testMirror("mirror", "origin")
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		switch request.URL.RequestURI() {
+		case "/nodes?parent_id=root":
+			return ListChildrenResponse{Items: []*Item{mirror}}
+		default:
+			t.Fatalf("unexpected HTTP request: %s", request.URL.RequestURI())
+			return nil
+		}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), root.ID, RecursiveFetchOptions{
+		Depth:          3,
+		ResolveMirrors: false,
+		Operation:      "get",
+		RootItem:       root,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Response.Items, 1)
+	assert.Empty(t, result.Response.Items[0].Children)
+	assert.Equal(t, []string{"/nodes?parent_id=root"}, requests.snapshot())
+}
+
+func TestRecursiveFetchEnabledUsesServerMirrorChildren(t *testing.T) {
+	mirror := testMirror("mirror", "origin")
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		require.Equal(t, "/nodes?parent_id=mirror", request.URL.RequestURI())
+		return ListChildrenResponse{Items: []*Item{testItem("origin-child")}}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), mirror.ID, RecursiveFetchOptions{
+		Depth:          1,
+		ResolveMirrors: true,
+		Operation:      "get",
+		RootItem:       mirror,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"origin-child"}, itemIDs(result.Response.Items))
+	assert.Equal(t, 1, result.Summary.Resolved)
+	assert.Equal(t, []string{"/nodes?parent_id=mirror"}, requests.snapshot())
+}
+
+func TestRecursiveFetchStopsMirrorCycle(t *testing.T) {
+	root := testItem("origin")
+	cycle := testMirror("cycle", root.ID)
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		require.Equal(t, "/nodes?parent_id=origin", request.URL.RequestURI())
+		return ListChildrenResponse{Items: []*Item{cycle}}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), root.ID, RecursiveFetchOptions{
+		Depth:          3,
+		ResolveMirrors: true,
+		Operation:      "get",
+		RootItem:       root,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Response.Items, 1)
+	assert.Empty(t, result.Response.Items[0].Children)
+	assert.Equal(t, 1, result.Summary.Cycles)
+	assert.Equal(t, []string{"/nodes?parent_id=origin"}, requests.snapshot())
+}
+
+func TestRecursiveFetchInternalRootSeedsCyclePath(t *testing.T) {
+	root := testItem("origin")
+	cycle := testMirror("cycle", root.ID)
+	client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		switch request.URL.RequestURI() {
+		case "/nodes/origin":
+			return GetItemResponse{Node: *root}
+		case "/nodes?parent_id=origin":
+			return ListChildrenResponse{Items: []*Item{cycle}}
+		default:
+			t.Fatalf("unexpected HTTP request: %s", request.URL.RequestURI())
+			return nil
+		}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), root.ID, RecursiveFetchOptions{
+		Depth:          3,
+		ResolveMirrors: true,
+		Operation:      "get",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Summary.Cycles)
+	assert.Equal(t, []string{"/nodes/origin", "/nodes?parent_id=origin"}, requests.snapshot())
+}
+
+func TestRecursiveFetchUsesMetadataForBothDeployments(t *testing.T) {
+	tests := []struct {
+		name   string
+		mirror *Item
+	}{
+		{name: "beta", mirror: testMirror("mirror", "origin")},
+		{name: "production backup shape", mirror: &Item{ID: "mirror", Data: map[string]interface{}{
+			"mirror": map[string]interface{}{"originalId": "origin"},
+		}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, requests := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+				t.Fatalf("unexpected HTTP request: %s", request.URL.RequestURI())
+				return nil
+			})
+
+			result, err := client.ListChildrenRecursiveWithOptions(context.Background(), test.mirror.ID, RecursiveFetchOptions{
+				Depth:          1,
+				ResolveMirrors: false,
+				Operation:      "get",
+				RootItem:       test.mirror,
+			})
+			require.NoError(t, err)
+			assert.Empty(t, result.Response.Items)
+			assert.Empty(t, requests.snapshot())
+		})
+	}
+}
+
+func TestRecursiveFetchReturnsResolutionSummaryAndLogsOneTraversalSummary(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	success := testMirror("success", "origin")
+	malformed := &Item{ID: "malformed", Data: map[string]interface{}{
+		"mirror": map[string]interface{}{"origin_id": false},
+	}}
+	client, _ := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		switch request.URL.Query().Get("parent_id") {
+		case "None":
+			return ListChildrenResponse{Items: []*Item{success, malformed}}
+		case "success", "malformed":
+			return ListChildrenResponse{}
+		default:
+			t.Fatalf("unexpected HTTP request: %s", request.URL.RequestURI())
+			return nil
+		}
+	})
+
+	result, err := client.ListChildrenRecursiveWithOptions(context.Background(), "None", RecursiveFetchOptions{
+		Depth:          2,
+		ResolveMirrors: true,
+		Operation:      "list",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, MirrorResolutionSummary{Resolved: 1, MalformedMetadata: 1}, result.Summary)
+	assert.Len(t, logs.withMessage("Workflowy recursive mirror traversal completed"), 1)
+	malformedLog := logs.requireOne(t, "Workflowy mirror metadata is malformed; using API children")
+	assert.Equal(t, "malformed", malformedLog.attrs["mirror_id"])
+	assert.Equal(t, "list", malformedLog.attrs["operation"])
+	assert.Len(t, logs.withMessage(result.Summary.ThresholdWarning("list", "Workflowy API")), 1)
+}
+
+func TestRecursiveFetchLogsContextualCycle(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	root := testMirror("entry", "origin")
+	client, _ := newRecursiveFetchTestClient(t, func(t *testing.T, request *http.Request) interface{} {
+		return ListChildrenResponse{Items: []*Item{testMirror("cycle", "origin")}}
+	})
+
+	_, err := client.ListChildrenRecursiveWithOptions(context.Background(), root.ID, RecursiveFetchOptions{
+		Depth:          2,
+		ResolveMirrors: true,
+		Operation:      "get",
+		RootItem:       root,
+	})
+	require.NoError(t, err)
+	cycleLog := logs.requireOne(t, "Workflowy mirror cycle stopped")
+	assert.Equal(t, "cycle", cycleLog.attrs["mirror_id"])
+	assert.Equal(t, "origin", cycleLog.attrs["origin_id"])
+	assert.Equal(t, "entry/cycle", cycleLog.attrs["path"])
+}
+
+type synchronizedRequests struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (requests *synchronizedRequests) append(path string) {
+	requests.mu.Lock()
+	defer requests.mu.Unlock()
+	requests.paths = append(requests.paths, path)
+}
+
+func (requests *synchronizedRequests) snapshot() []string {
+	requests.mu.Lock()
+	defer requests.mu.Unlock()
+	return append([]string(nil), requests.paths...)
+}
+
+func newRecursiveFetchTestClient(
+	t *testing.T,
+	response func(*testing.T, *http.Request) interface{},
+) (*WorkflowyClient, *synchronizedRequests) {
+	t.Helper()
+	requests := &synchronizedRequests{}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests.append(request.URL.RequestURI())
+		writer.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(writer).Encode(response(t, request)))
+	}))
+	t.Cleanup(server.Close)
+	return &WorkflowyClient{Client: workflowyclient.New(server.URL)}, requests
+}

--- a/pkg/workflowy/resolve.go
+++ b/pkg/workflowy/resolve.go
@@ -1,0 +1,58 @@
+package workflowy
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var fullNodeIDPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+func ResolveNodeIDFromTree(items []*Item, rawID string) (string, error) {
+	if rawID == "" || rawID == "None" {
+		return rawID, nil
+	}
+
+	nodeID := nodeIDFromURL(rawID)
+
+	if IsFullNodeID(rawID) {
+		if FindItemByID(items, nodeID) == nil {
+			return "", fmt.Errorf("Cannot resolve Workflowy node %q from tree: node was not found", rawID)
+		}
+		return nodeID, nil
+	}
+
+	if !IsShortID(nodeID) {
+		return "", fmt.Errorf("Cannot resolve Workflowy node %q from tree: expected a full UUID or 12-character short ID", rawID)
+	}
+
+	matches := findNodeIDsWithSuffix(items, nodeID)
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("Cannot resolve Workflowy node %q from tree: node was not found", rawID)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("Cannot resolve Workflowy node %q from tree: short ID matches %d nodes", rawID, len(matches))
+	}
+}
+
+func IsFullNodeID(rawID string) bool {
+	return fullNodeIDPattern.MatchString(nodeIDFromURL(rawID))
+}
+
+func nodeIDFromURL(rawID string) string {
+	nodeID := strings.TrimPrefix(rawID, "https://workflowy.com/#/")
+	return strings.TrimPrefix(nodeID, "https://beta.workflowy.com/#/")
+}
+
+func findNodeIDsWithSuffix(items []*Item, suffix string) []string {
+	var matches []string
+	for _, item := range items {
+		if strings.HasSuffix(item.ID, suffix) {
+			matches = append(matches, item.ID)
+		}
+		matches = append(matches, findNodeIDsWithSuffix(item.Children, suffix)...)
+	}
+	return matches
+}

--- a/pkg/workflowy/resolve_test.go
+++ b/pkg/workflowy/resolve_test.go
@@ -1,0 +1,50 @@
+package workflowy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveNodeIDFromTree(t *testing.T) {
+	items := []*Item{
+		{ID: "11111111-1111-1111-1111-aaaaaaaaaaaa", Name: "First"},
+		{ID: "22222222-2222-2222-2222-bbbbbbbbbbbb", Name: "Second"},
+	}
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "none", raw: "None", want: "None"},
+		{name: "full UUID", raw: "11111111-1111-1111-1111-aaaaaaaaaaaa", want: "11111111-1111-1111-1111-aaaaaaaaaaaa"},
+		{name: "Workflowy URL", raw: "https://workflowy.com/#/11111111-1111-1111-1111-aaaaaaaaaaaa", want: "11111111-1111-1111-1111-aaaaaaaaaaaa"},
+		{name: "short ID", raw: "bbbbbbbbbbbb", want: "22222222-2222-2222-2222-bbbbbbbbbbbb"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ResolveNodeIDFromTree(items, test.raw)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestResolveNodeIDFromTreeReportsMissingAndAmbiguousIDs(t *testing.T) {
+	items := []*Item{
+		{ID: "11111111-1111-1111-1111-aaaaaaaaaaaa"},
+		{ID: "22222222-2222-2222-2222-aaaaaaaaaaaa"},
+	}
+
+	_, err := ResolveNodeIDFromTree(items, "33333333-3333-3333-3333-cccccccccccc")
+	require.EqualError(t, err, `Cannot resolve Workflowy node "33333333-3333-3333-3333-cccccccccccc" from tree: node was not found`)
+
+	_, err = ResolveNodeIDFromTree(items, "aaaaaaaaaaaa")
+	require.EqualError(t, err, `Cannot resolve Workflowy node "aaaaaaaaaaaa" from tree: short ID matches 2 nodes`)
+
+	_, err = ResolveNodeIDFromTree(items, "inbox")
+	require.EqualError(t, err, `Cannot resolve Workflowy node "inbox" from tree: expected a full UUID or 12-character short ID`)
+}

--- a/pkg/workflowy/resolved_tree.go
+++ b/pkg/workflowy/resolved_tree.go
@@ -1,0 +1,212 @@
+package workflowy
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+type ResolveOptions struct {
+	ResolveMirrors bool
+	Depth          int
+	Operation      string
+}
+
+type MirrorResolutionSummary struct {
+	Resolved          int
+	MissingOrigin     int
+	MalformedMetadata int
+	Cycles            int
+}
+
+type ResolvedFetch struct {
+	Item       *Item
+	Items      []*Item
+	Occurrence NodeOccurrence
+	Summary    MirrorResolutionSummary
+}
+
+type NodeOccurrence struct {
+	Item      *Item
+	Ancestors []*Item
+	ViaMirror bool
+}
+
+type OccurrenceVisitResult struct {
+	RetainedOccurrences int
+}
+
+type OccurrenceVisitor func(NodeOccurrence) (OccurrenceVisitResult, error)
+
+type sourceNode struct {
+	item   *Item
+	parent *sourceNode
+}
+
+type ResolvedTree struct {
+	sourceRoots       []*Item
+	sourceLabel       string
+	index             map[string]*sourceNode
+	logger            *slog.Logger
+	memoryStatsReader func() traversalMemoryStats
+	sourceNodeCount   int
+	mirrorCount       int
+}
+
+func NewResolvedTree(sourceRoots []*Item, sourceLabel string) *ResolvedTree {
+	tree := &ResolvedTree{
+		sourceRoots:       sourceRoots,
+		sourceLabel:       sourceLabel,
+		index:             make(map[string]*sourceNode),
+		logger:            slog.Default(),
+		memoryStatsReader: readTraversalMemoryStats,
+	}
+	for _, root := range sourceRoots {
+		tree.indexSource(root, nil)
+	}
+	tree.logger.Debug(
+		"indexed Workflowy resolved tree source",
+		"source", sourceLabel,
+		"source_roots", len(sourceRoots),
+		"source_nodes", tree.sourceNodeCount,
+		"mirrors", tree.mirrorCount,
+	)
+	return tree
+}
+
+func (tree *ResolvedTree) indexSource(item *Item, parent *sourceNode) {
+	if item == nil {
+		return
+	}
+	tree.sourceNodeCount++
+	if MirrorReferenceFromItem(item).IsMirror() {
+		tree.mirrorCount++
+	}
+
+	node := &sourceNode{item: item, parent: parent}
+	if _, exists := tree.index[item.ID]; !exists {
+		tree.index[item.ID] = node
+	}
+	for _, child := range item.Children {
+		tree.indexSource(child, node)
+	}
+}
+
+func (tree *ResolvedTree) Fetch(readScopeID, targetID string, options ResolveOptions) (*ResolvedFetch, error) {
+	tracker := newResolutionTracker(tree, readScopeID, targetID, options)
+	defer tracker.finish()
+	scope, err := tree.readScope(readScopeID, options, tracker)
+	if err != nil {
+		return nil, err
+	}
+
+	if targetID == "None" || targetID == "" {
+		items := make([]*Item, 0, len(scope))
+		for _, selection := range scope {
+			items = append(items, tree.materialize(selection, options.Depth, options, tracker))
+		}
+		return &ResolvedFetch{Items: items, Summary: tracker.summary}, nil
+	}
+
+	selection := tree.preferredSelection(scope, readScopeID, targetID, options, tracker)
+	if selection == nil {
+		return nil, fmt.Errorf(
+			"Cannot find Workflowy node %q within resolved read scope %q from %s",
+			targetID,
+			readScopeID,
+			tree.sourceLabel,
+		)
+	}
+
+	item := tree.materialize(*selection, options.Depth, options, tracker)
+	return &ResolvedFetch{
+		Item:       item,
+		Occurrence: selection.occurrence.Snapshot(),
+		Summary:    tracker.summary,
+	}, nil
+}
+
+func (tree *ResolvedTree) readScope(readScopeID string, options ResolveOptions, tracker *resolutionTracker) ([]nodeSelection, error) {
+	if readScopeID == "" || readScopeID == "None" {
+		selections := make([]nodeSelection, 0, len(tree.sourceRoots))
+		for _, root := range tree.sourceRoots {
+			selections = append(selections, selectionForRoot(root))
+		}
+		return selections, nil
+	}
+
+	rootSelections := make([]nodeSelection, 0, len(tree.sourceRoots))
+	for _, root := range tree.sourceRoots {
+		rootSelections = append(rootSelections, selectionForRoot(root))
+	}
+	selection := tree.preferredSelection(rootSelections, "None", readScopeID, options, tracker)
+	if selection == nil {
+		return nil, fmt.Errorf(
+			"Cannot find Workflowy read scope %q in %s",
+			readScopeID,
+			tree.sourceLabel,
+		)
+	}
+	return []nodeSelection{*selection}, nil
+}
+
+func selectionForRoot(root *Item) nodeSelection {
+	active := []string{root.ID}
+	return nodeSelection{
+		occurrence: NodeOccurrence{Item: root, ViaMirror: MirrorReferenceFromItem(root).IsMirror()},
+		activeIDs:  active,
+	}
+}
+
+func cloneItemWithoutChildren(item *Item) *Item {
+	if item == nil {
+		return nil
+	}
+	clone := *item
+	clone.Note = cloneStringPointer(item.Note)
+	clone.CompletedAt = cloneInt64Pointer(item.CompletedAt)
+	clone.Data = cloneStringMap(item.Data)
+	clone.Children = nil
+	return &clone
+}
+
+func cloneStringPointer(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneInt64Pointer(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneStringMap(source map[string]interface{}) map[string]interface{} {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]interface{}, len(source))
+	for key, value := range source {
+		clone[key] = cloneDataValue(value)
+	}
+	return clone
+}
+
+func cloneDataValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return cloneStringMap(typed)
+	case []interface{}:
+		clone := make([]interface{}, len(typed))
+		for index, element := range typed {
+			clone[index] = cloneDataValue(element)
+		}
+		return clone
+	default:
+		return value
+	}
+}

--- a/pkg/workflowy/resolved_tree.go
+++ b/pkg/workflowy/resolved_tree.go
@@ -83,12 +83,27 @@ func (tree *ResolvedTree) indexSource(item *Item, parent *sourceNode) {
 	}
 
 	node := &sourceNode{item: item, parent: parent}
-	if _, exists := tree.index[item.ID]; !exists {
+	if existing, exists := tree.index[item.ID]; exists {
+		tree.logger.Error(
+			"Cannot index duplicate Workflowy node ID",
+			"node_id", item.ID,
+			"source", tree.sourceLabel,
+			"first_parent_id", sourceParentID(existing.parent),
+			"duplicate_parent_id", sourceParentID(parent),
+		)
+	} else {
 		tree.index[item.ID] = node
 	}
 	for _, child := range item.Children {
 		tree.indexSource(child, node)
 	}
+}
+
+func sourceParentID(parent *sourceNode) string {
+	if parent == nil {
+		return "None"
+	}
+	return parent.item.ID
 }
 
 func (tree *ResolvedTree) Fetch(readScopeID, targetID string, options ResolveOptions) (*ResolvedFetch, error) {

--- a/pkg/workflowy/resolved_tree_diagnostics.go
+++ b/pkg/workflowy/resolved_tree_diagnostics.go
@@ -1,0 +1,251 @@
+package workflowy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"time"
+)
+
+const traversalProgressStart = 1000
+
+type traversalMemoryStats struct {
+	HeapBytes           uint64
+	HeapObjects         uint64
+	TotalAllocatedBytes uint64
+	GarbageCollections  uint32
+}
+
+type cycleDiagnostic struct {
+	mirrorID    string
+	originID    string
+	firstPath   string
+	occurrences int
+}
+
+type resolutionTracker struct {
+	tree                *ResolvedTree
+	options             ResolveOptions
+	readScopeID         string
+	targetID            string
+	startedAt           time.Time
+	debugEnabled        bool
+	summary             MirrorResolutionSummary
+	seenEvents          map[string]struct{}
+	seenOccurrences     map[string]struct{}
+	retainedIdentities  map[string]struct{}
+	cycles              map[string]*cycleDiagnostic
+	visitedOccurrences  int
+	retainedOccurrences int
+	currentPathDepth    int
+	maximumPathDepth    int
+	nextProgress        int
+}
+
+func (summary MirrorResolutionSummary) Attempts() int {
+	return summary.Resolved + summary.Failures()
+}
+
+func (summary MirrorResolutionSummary) Failures() int {
+	return summary.MissingOrigin + summary.MalformedMetadata + summary.Cycles
+}
+
+func (summary MirrorResolutionSummary) ThresholdWarning(operation, source string) string {
+	attempts := summary.Attempts()
+	if attempts == 0 || summary.Failures()*2 < attempts {
+		return ""
+	}
+	failureRatio := float64(summary.Failures()) / float64(attempts) * 100
+	return fmt.Sprintf(
+		"Mirror resolution failures reached %.1f%% during %s from %s (attempts=%d failures=%d resolved=%d missing_origin=%d malformed_metadata=%d cycles=%d)",
+		failureRatio,
+		operation,
+		source,
+		attempts,
+		summary.Failures(),
+		summary.Resolved,
+		summary.MissingOrigin,
+		summary.MalformedMetadata,
+		summary.Cycles,
+	)
+}
+
+func readTraversalMemoryStats() traversalMemoryStats {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return traversalMemoryStats{
+		HeapBytes:           stats.HeapAlloc,
+		HeapObjects:         stats.HeapObjects,
+		TotalAllocatedBytes: stats.TotalAlloc,
+		GarbageCollections:  stats.NumGC,
+	}
+}
+
+func newResolutionTracker(tree *ResolvedTree, readScopeID, targetID string, options ResolveOptions) *resolutionTracker {
+	tracker := &resolutionTracker{
+		tree:               tree,
+		options:            options,
+		readScopeID:        readScopeID,
+		targetID:           targetID,
+		startedAt:          time.Now(),
+		debugEnabled:       tree.logger.Enabled(context.Background(), slog.LevelDebug),
+		seenEvents:         make(map[string]struct{}),
+		seenOccurrences:    make(map[string]struct{}),
+		retainedIdentities: make(map[string]struct{}),
+		cycles:             make(map[string]*cycleDiagnostic),
+		nextProgress:       traversalProgressStart,
+	}
+	if tracker.debugEnabled {
+		tracker.logWithMemory(slog.LevelDebug, "Workflowy mirror traversal started")
+	}
+	return tracker
+}
+
+func (tracker *resolutionTracker) observe(selection nodeSelection) {
+	identity := selection.occurrence.Identity()
+	if _, exists := tracker.seenOccurrences[identity]; exists {
+		return
+	}
+	tracker.seenOccurrences[identity] = struct{}{}
+	tracker.visitedOccurrences++
+	tracker.currentPathDepth = len(selection.occurrence.Ancestors) + 1
+	if tracker.currentPathDepth > tracker.maximumPathDepth {
+		tracker.maximumPathDepth = tracker.currentPathDepth
+	}
+	if tracker.debugEnabled && tracker.visitedOccurrences >= tracker.nextProgress {
+		tracker.logWithMemory(slog.LevelDebug, "Workflowy mirror traversal progress")
+		tracker.nextProgress *= 2
+	}
+}
+
+func (tracker *resolutionTracker) retain(selection nodeSelection) {
+	identity := selection.occurrence.Identity()
+	if _, exists := tracker.retainedIdentities[identity]; exists {
+		return
+	}
+	tracker.retainedIdentities[identity] = struct{}{}
+	tracker.retainedOccurrences++
+}
+
+func (tracker *resolutionTracker) record(kind string, selection nodeSelection, reference MirrorReference) {
+	identity := selection.occurrence.Identity()
+	eventKey := kind + "\x00" + identity
+	if _, exists := tracker.seenEvents[eventKey]; exists {
+		return
+	}
+	tracker.seenEvents[eventKey] = struct{}{}
+
+	switch kind {
+	case "resolved":
+		tracker.summary.Resolved++
+	case "missing":
+		tracker.summary.MissingOrigin++
+		tracker.tree.logger.Warn(
+			"Workflowy mirror origin is missing; using source children",
+			"mirror_id", selection.occurrence.Item.ID,
+			"origin_id", reference.OriginID,
+			"path", identity,
+			"source", tracker.tree.sourceLabel,
+			"operation", tracker.options.Operation,
+		)
+	case "malformed":
+		tracker.summary.MalformedMetadata++
+		tracker.tree.logger.Warn(
+			"Workflowy mirror metadata is malformed; using source children",
+			"mirror_id", selection.occurrence.Item.ID,
+			"field", reference.Field,
+			"value_type", reference.ValueType,
+			"path", identity,
+			"source", tracker.tree.sourceLabel,
+			"operation", tracker.options.Operation,
+		)
+	case "cycle":
+		tracker.summary.Cycles++
+		key := selection.occurrence.Item.ID + "\x00" + reference.OriginID
+		diagnostic := tracker.cycles[key]
+		if diagnostic == nil {
+			diagnostic = &cycleDiagnostic{
+				mirrorID:  selection.occurrence.Item.ID,
+				originID:  reference.OriginID,
+				firstPath: identity,
+			}
+			tracker.cycles[key] = diagnostic
+		}
+		diagnostic.occurrences++
+	}
+}
+
+func (tracker *resolutionTracker) finish() {
+	for _, diagnostic := range tracker.cycles {
+		tracker.tree.logger.Warn(
+			"Workflowy mirror cycle stopped",
+			"mirror_id", diagnostic.mirrorID,
+			"origin_id", diagnostic.originID,
+			"path", diagnostic.firstPath,
+			"occurrences", diagnostic.occurrences,
+			"source", tracker.tree.sourceLabel,
+			"operation", tracker.options.Operation,
+		)
+	}
+
+	if warning := tracker.summary.ThresholdWarning(tracker.options.Operation, tracker.tree.sourceLabel); warning != "" {
+		tracker.tree.logger.Warn(
+			warning,
+			"attempts", tracker.summary.Attempts(),
+			"failures", tracker.summary.Failures(),
+			"failure_ratio", float64(tracker.summary.Failures())/float64(tracker.summary.Attempts()),
+			"source", tracker.tree.sourceLabel,
+			"operation", tracker.options.Operation,
+		)
+	}
+
+	tracker.logCompletion()
+}
+
+func (tracker *resolutionTracker) logCompletion() {
+	attributes := tracker.commonAttributes()
+	attributes = append(attributes,
+		"resolved", tracker.summary.Resolved,
+		"missing_origin", tracker.summary.MissingOrigin,
+		"malformed_metadata", tracker.summary.MalformedMetadata,
+		"cycles", tracker.summary.Cycles,
+		"attempts", tracker.summary.Attempts(),
+		"failures", tracker.summary.Failures(),
+	)
+	if tracker.debugEnabled {
+		attributes = append(attributes, tracker.memoryAttributes()...)
+	}
+	tracker.tree.logger.Info("Workflowy mirror traversal completed", attributes...)
+}
+
+func (tracker *resolutionTracker) logWithMemory(level slog.Level, message string) {
+	attributes := append(tracker.commonAttributes(), tracker.memoryAttributes()...)
+	tracker.tree.logger.Log(context.Background(), level, message, attributes...)
+}
+
+func (tracker *resolutionTracker) commonAttributes() []interface{} {
+	return []interface{}{
+		"operation", tracker.options.Operation,
+		"source", tracker.tree.sourceLabel,
+		"scope", tracker.readScopeID,
+		"target", tracker.targetID,
+		"requested_depth", tracker.options.Depth,
+		"effective_depth", tracker.options.Depth,
+		"visited_occurrences", tracker.visitedOccurrences,
+		"retained_occurrences", tracker.retainedOccurrences,
+		"current_path_depth", tracker.currentPathDepth,
+		"maximum_path_depth", tracker.maximumPathDepth,
+		"elapsed", time.Since(tracker.startedAt),
+	}
+}
+
+func (tracker *resolutionTracker) memoryAttributes() []interface{} {
+	stats := tracker.tree.memoryStatsReader()
+	return []interface{}{
+		"heap_bytes", stats.HeapBytes,
+		"heap_objects", stats.HeapObjects,
+		"total_allocated_bytes", stats.TotalAllocatedBytes,
+		"gc_count", stats.GarbageCollections,
+	}
+}

--- a/pkg/workflowy/resolved_tree_diagnostics.go
+++ b/pkg/workflowy/resolved_tree_diagnostics.go
@@ -32,9 +32,6 @@ type resolutionTracker struct {
 	startedAt           time.Time
 	debugEnabled        bool
 	summary             MirrorResolutionSummary
-	seenEvents          map[string]struct{}
-	seenOccurrences     map[string]struct{}
-	retainedIdentities  map[string]struct{}
 	cycles              map[string]*cycleDiagnostic
 	visitedOccurrences  int
 	retainedOccurrences int
@@ -84,17 +81,14 @@ func readTraversalMemoryStats() traversalMemoryStats {
 
 func newResolutionTracker(tree *ResolvedTree, readScopeID, targetID string, options ResolveOptions) *resolutionTracker {
 	tracker := &resolutionTracker{
-		tree:               tree,
-		options:            options,
-		readScopeID:        readScopeID,
-		targetID:           targetID,
-		startedAt:          time.Now(),
-		debugEnabled:       tree.logger.Enabled(context.Background(), slog.LevelDebug),
-		seenEvents:         make(map[string]struct{}),
-		seenOccurrences:    make(map[string]struct{}),
-		retainedIdentities: make(map[string]struct{}),
-		cycles:             make(map[string]*cycleDiagnostic),
-		nextProgress:       traversalProgressStart,
+		tree:         tree,
+		options:      options,
+		readScopeID:  readScopeID,
+		targetID:     targetID,
+		startedAt:    time.Now(),
+		debugEnabled: tree.logger.Enabled(context.Background(), slog.LevelDebug),
+		cycles:       make(map[string]*cycleDiagnostic),
+		nextProgress: traversalProgressStart,
 	}
 	if tracker.debugEnabled {
 		tracker.logWithMemory(slog.LevelDebug, "Workflowy mirror traversal started")
@@ -103,11 +97,6 @@ func newResolutionTracker(tree *ResolvedTree, readScopeID, targetID string, opti
 }
 
 func (tracker *resolutionTracker) observe(selection nodeSelection) {
-	identity := selection.occurrence.Identity()
-	if _, exists := tracker.seenOccurrences[identity]; exists {
-		return
-	}
-	tracker.seenOccurrences[identity] = struct{}{}
 	tracker.visitedOccurrences++
 	tracker.currentPathDepth = len(selection.occurrence.Ancestors) + 1
 	if tracker.currentPathDepth > tracker.maximumPathDepth {
@@ -119,28 +108,17 @@ func (tracker *resolutionTracker) observe(selection nodeSelection) {
 	}
 }
 
-func (tracker *resolutionTracker) retain(selection nodeSelection) {
-	identity := selection.occurrence.Identity()
-	if _, exists := tracker.retainedIdentities[identity]; exists {
-		return
-	}
-	tracker.retainedIdentities[identity] = struct{}{}
+func (tracker *resolutionTracker) retain() {
 	tracker.retainedOccurrences++
 }
 
 func (tracker *resolutionTracker) record(kind string, selection nodeSelection, reference MirrorReference) {
-	identity := selection.occurrence.Identity()
-	eventKey := kind + "\x00" + identity
-	if _, exists := tracker.seenEvents[eventKey]; exists {
-		return
-	}
-	tracker.seenEvents[eventKey] = struct{}{}
-
 	switch kind {
 	case "resolved":
 		tracker.summary.Resolved++
 	case "missing":
 		tracker.summary.MissingOrigin++
+		identity := selection.occurrence.Identity()
 		tracker.tree.logger.Warn(
 			"Workflowy mirror origin is missing; using source children",
 			"mirror_id", selection.occurrence.Item.ID,
@@ -151,6 +129,7 @@ func (tracker *resolutionTracker) record(kind string, selection nodeSelection, r
 		)
 	case "malformed":
 		tracker.summary.MalformedMetadata++
+		identity := selection.occurrence.Identity()
 		tracker.tree.logger.Warn(
 			"Workflowy mirror metadata is malformed; using source children",
 			"mirror_id", selection.occurrence.Item.ID,
@@ -162,6 +141,7 @@ func (tracker *resolutionTracker) record(kind string, selection nodeSelection, r
 		)
 	case "cycle":
 		tracker.summary.Cycles++
+		identity := selection.occurrence.Identity()
 		key := selection.occurrence.Item.ID + "\x00" + reference.OriginID
 		diagnostic := tracker.cycles[key]
 		if diagnostic == nil {

--- a/pkg/workflowy/resolved_tree_diagnostics_test.go
+++ b/pkg/workflowy/resolved_tree_diagnostics_test.go
@@ -1,0 +1,219 @@
+package workflowy
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMirrorResolutionSummaryMetricsAndThresholdWarning(t *testing.T) {
+	summary := MirrorResolutionSummary{Resolved: 2, MissingOrigin: 1, MalformedMetadata: 1, Cycles: 2}
+
+	assert.Equal(t, 6, summary.Attempts())
+	assert.Equal(t, 4, summary.Failures())
+	assert.Equal(t,
+		"Mirror resolution failures reached 66.7% during search from test export (attempts=6 failures=4 resolved=2 missing_origin=1 malformed_metadata=1 cycles=2)",
+		summary.ThresholdWarning("search", "test export"),
+	)
+	assert.Empty(t, (MirrorResolutionSummary{Resolved: 2, MissingOrigin: 1}).ThresholdWarning("get", "test export"))
+	assert.NotEmpty(t, (MirrorResolutionSummary{Resolved: 1, MissingOrigin: 1}).ThresholdWarning("get", "test export"))
+	assert.Empty(t, (MirrorResolutionSummary{}).ThresholdWarning("get", "test export"))
+}
+
+func TestResolvedTreeLogsContextualFallbacksAndOneSummary(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	malformed := &Item{ID: "malformed", Data: map[string]interface{}{
+		"mirror": map[string]interface{}{"origin_id": 17},
+	}}
+	missing := testMirror("missing", "absent")
+	tree := NewResolvedTree([]*Item{malformed, missing}, "test export")
+
+	_, err := tree.Fetch("None", "None", resolvedFetchOptions(1))
+	require.NoError(t, err)
+
+	malformedRecord := logs.requireOne(t, "Workflowy mirror metadata is malformed; using source children")
+	assert.Equal(t, "malformed", malformedRecord.attrs["mirror_id"])
+	assert.Equal(t, "origin_id", malformedRecord.attrs["field"])
+	assert.Equal(t, "int", malformedRecord.attrs["value_type"])
+	assert.Equal(t, "test export", malformedRecord.attrs["source"])
+	assert.Equal(t, "get", malformedRecord.attrs["operation"])
+
+	missingRecord := logs.requireOne(t, "Workflowy mirror origin is missing; using source children")
+	assert.Equal(t, "missing", missingRecord.attrs["mirror_id"])
+	assert.Equal(t, "absent", missingRecord.attrs["origin_id"])
+	assert.Equal(t, "missing", missingRecord.attrs["path"])
+	assert.Len(t, logs.withMessage("Workflowy mirror traversal completed"), 1)
+}
+
+func TestResolvedTreeLogsConsolidatedCycles(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	selfMirror := testMirror("self-mirror", "origin")
+	origin := testItem("origin", selfMirror)
+	tree := NewResolvedTree([]*Item{origin, testMirror("entry-one", origin.ID), testMirror("entry-two", origin.ID)}, "test backup")
+
+	result, err := tree.Fetch("None", "None", resolvedFetchOptions(-1))
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.Summary.Cycles)
+
+	cycleRecord := logs.requireOne(t, "Workflowy mirror cycle stopped")
+	assert.Equal(t, "self-mirror", cycleRecord.attrs["mirror_id"])
+	assert.Equal(t, "origin", cycleRecord.attrs["origin_id"])
+	assert.Equal(t, int64(3), cycleRecord.attrs["occurrences"])
+	assert.NotEmpty(t, cycleRecord.attrs["path"])
+}
+
+func TestResolvedTreeLogsIndexTraversalProgressAndCompletion(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	roots := make([]*Item, 4096)
+	for index := range roots {
+		roots[index] = testItem(stringID(index))
+	}
+	tree := NewResolvedTree(roots, "large export")
+	tree.memoryStatsReader = func() traversalMemoryStats {
+		return traversalMemoryStats{HeapBytes: 10, HeapObjects: 20, TotalAllocatedBytes: 30, GarbageCollections: 40}
+	}
+
+	_, err := tree.Visit("None", "None", resolvedFetchOptions(0), func(NodeOccurrence) (OccurrenceVisitResult, error) {
+		return OccurrenceVisitResult{RetainedOccurrences: 7}, nil
+	})
+	require.NoError(t, err)
+
+	indexRecord := logs.requireOne(t, "indexed Workflowy resolved tree source")
+	assert.Equal(t, int64(4096), indexRecord.attrs["source_roots"])
+	assert.Equal(t, int64(4096), indexRecord.attrs["source_nodes"])
+	assert.Equal(t, int64(0), indexRecord.attrs["mirrors"])
+
+	start := logs.requireOne(t, "Workflowy mirror traversal started")
+	assertTraversalContext(t, start, "get", "large export", "None", "None", int64(0))
+
+	progress := logs.withMessage("Workflowy mirror traversal progress")
+	require.Len(t, progress, 3)
+	assert.Equal(t, int64(1000), progress[0].attrs["visited_occurrences"])
+	assert.Equal(t, int64(2000), progress[1].attrs["visited_occurrences"])
+	assert.Equal(t, int64(4000), progress[2].attrs["visited_occurrences"])
+
+	completion := logs.requireOne(t, "Workflowy mirror traversal completed")
+	assertTraversalContext(t, completion, "get", "large export", "None", "None", int64(0))
+	assert.Equal(t, int64(4096), completion.attrs["visited_occurrences"])
+	assert.Equal(t, int64(7), completion.attrs["retained_occurrences"])
+	assert.Equal(t, int64(1), completion.attrs["maximum_path_depth"])
+	assertTraversalMemory(t, completion)
+}
+
+func TestResolvedTreeDoesNotReadMemoryStatsWhenDebugLoggingIsDisabled(t *testing.T) {
+	captureResolvedTreeLogs(t, slog.LevelInfo)
+	tree := NewResolvedTree([]*Item{testItem("root")}, "test export")
+	reads := 0
+	tree.memoryStatsReader = func() traversalMemoryStats {
+		reads++
+		return traversalMemoryStats{}
+	}
+
+	_, err := tree.Fetch("None", "None", resolvedFetchOptions(0))
+	require.NoError(t, err)
+	assert.Zero(t, reads)
+}
+
+func TestResolvedTreeLogsMirrorTargetWithoutDoubleCounting(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	child := testItem("child")
+	origin := testItem("origin", child)
+	mirror := testMirror("mirror", origin.ID)
+	tree := NewResolvedTree([]*Item{mirror, origin}, "test export")
+
+	result, err := tree.Fetch("None", mirror.ID, resolvedFetchOptions(-1))
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Summary.Resolved)
+
+	completion := logs.requireOne(t, "Workflowy mirror traversal completed")
+	assert.Equal(t, int64(2), completion.attrs["visited_occurrences"])
+	assert.Equal(t, int64(2), completion.attrs["retained_occurrences"])
+	assert.Equal(t, int64(1), completion.attrs["resolved"])
+}
+
+func assertTraversalContext(t *testing.T, record capturedLogRecord, operation, source, scope, target string, depth int64) {
+	t.Helper()
+	assert.Equal(t, operation, record.attrs["operation"])
+	assert.Equal(t, source, record.attrs["source"])
+	assert.Equal(t, scope, record.attrs["scope"])
+	assert.Equal(t, target, record.attrs["target"])
+	assert.Equal(t, depth, record.attrs["requested_depth"])
+	assert.Equal(t, depth, record.attrs["effective_depth"])
+}
+
+func assertTraversalMemory(t *testing.T, record capturedLogRecord) {
+	t.Helper()
+	assert.Equal(t, uint64(10), record.attrs["heap_bytes"])
+	assert.Equal(t, uint64(20), record.attrs["heap_objects"])
+	assert.Equal(t, uint64(30), record.attrs["total_allocated_bytes"])
+	assert.Equal(t, uint64(40), record.attrs["gc_count"])
+	assert.Contains(t, record.attrs, "elapsed")
+	assert.Contains(t, record.attrs, "current_path_depth")
+}
+
+func stringID(index int) string {
+	return "node-" + strconv.Itoa(index)
+}
+
+type capturedLogRecord struct {
+	message string
+	attrs   map[string]interface{}
+}
+
+type capturedLogs struct {
+	mu      sync.Mutex
+	level   slog.Level
+	records []capturedLogRecord
+}
+
+func captureResolvedTreeLogs(t *testing.T, level slog.Level) *capturedLogs {
+	t.Helper()
+	logs := &capturedLogs{level: level}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(logs))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return logs
+}
+
+func (logs *capturedLogs) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= logs.level
+}
+
+func (logs *capturedLogs) Handle(_ context.Context, record slog.Record) error {
+	attrs := make(map[string]interface{})
+	record.Attrs(func(attribute slog.Attr) bool {
+		attrs[attribute.Key] = attribute.Value.Any()
+		return true
+	})
+	logs.mu.Lock()
+	defer logs.mu.Unlock()
+	logs.records = append(logs.records, capturedLogRecord{message: record.Message, attrs: attrs})
+	return nil
+}
+
+func (logs *capturedLogs) WithAttrs(_ []slog.Attr) slog.Handler { return logs }
+func (logs *capturedLogs) WithGroup(_ string) slog.Handler      { return logs }
+
+func (logs *capturedLogs) withMessage(message string) []capturedLogRecord {
+	logs.mu.Lock()
+	defer logs.mu.Unlock()
+	matching := make([]capturedLogRecord, 0)
+	for _, record := range logs.records {
+		if record.message == message {
+			matching = append(matching, record)
+		}
+	}
+	return matching
+}
+
+func (logs *capturedLogs) requireOne(t *testing.T, message string) capturedLogRecord {
+	t.Helper()
+	records := logs.withMessage(message)
+	require.Len(t, records, 1, "records with message %q", message)
+	return records[0]
+}

--- a/pkg/workflowy/resolved_tree_diagnostics_test.go
+++ b/pkg/workflowy/resolved_tree_diagnostics_test.go
@@ -3,7 +3,9 @@ package workflowy
 import (
 	"context"
 	"log/slog"
+	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -119,6 +121,20 @@ func TestResolvedTreeDoesNotReadMemoryStatsWhenDebugLoggingIsDisabled(t *testing
 	assert.Zero(t, reads)
 }
 
+func TestResolvedTreeLogsDuplicateSourceIDs(t *testing.T) {
+	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
+	NewResolvedTree([]*Item{
+		testItem("first-parent", testItem("duplicate")),
+		testItem("second-parent", testItem("duplicate")),
+	}, "test export")
+
+	record := logs.requireOne(t, "Cannot index duplicate Workflowy node ID")
+	assert.Equal(t, "duplicate", record.attrs["node_id"])
+	assert.Equal(t, "test export", record.attrs["source"])
+	assert.Equal(t, "first-parent", record.attrs["first_parent_id"])
+	assert.Equal(t, "second-parent", record.attrs["duplicate_parent_id"])
+}
+
 func TestResolvedTreeLogsMirrorTargetWithoutDoubleCounting(t *testing.T) {
 	logs := captureResolvedTreeLogs(t, slog.LevelDebug)
 	child := testItem("child")
@@ -134,6 +150,22 @@ func TestResolvedTreeLogsMirrorTargetWithoutDoubleCounting(t *testing.T) {
 	assert.Equal(t, int64(2), completion.attrs["visited_occurrences"])
 	assert.Equal(t, int64(2), completion.attrs["retained_occurrences"])
 	assert.Equal(t, int64(1), completion.attrs["resolved"])
+}
+
+func TestTraversalTrackersRetainOnlyConsolidatedCycleState(t *testing.T) {
+	assert.Equal(t, []string{"cycles"}, mapFieldNames(reflect.TypeOf(resolutionTracker{})))
+	assert.Equal(t, []string{"cycles"}, mapFieldNames(reflect.TypeOf(recursiveFetchTracker{})))
+}
+
+func mapFieldNames(structType reflect.Type) []string {
+	fields := make([]string, 0)
+	for index := 0; index < structType.NumField(); index++ {
+		field := structType.Field(index)
+		if field.Type.Kind() == reflect.Map {
+			fields = append(fields, field.Name)
+		}
+	}
+	return fields
 }
 
 func assertTraversalContext(t *testing.T, record capturedLogRecord, operation, source, scope, target string, depth int64) {
@@ -205,6 +237,18 @@ func (logs *capturedLogs) withMessage(message string) []capturedLogRecord {
 	matching := make([]capturedLogRecord, 0)
 	for _, record := range logs.records {
 		if record.message == message {
+			matching = append(matching, record)
+		}
+	}
+	return matching
+}
+
+func (logs *capturedLogs) withMessagePrefix(prefix string) []capturedLogRecord {
+	logs.mu.Lock()
+	defer logs.mu.Unlock()
+	matching := make([]capturedLogRecord, 0)
+	for _, record := range logs.records {
+		if strings.HasPrefix(record.message, prefix) {
 			matching = append(matching, record)
 		}
 	}

--- a/pkg/workflowy/resolved_tree_fetch_test.go
+++ b/pkg/workflowy/resolved_tree_fetch_test.go
@@ -119,6 +119,17 @@ func TestResolvedTreeFetchDoesNotTraverseUnrequestedCycles(t *testing.T) {
 	assert.Zero(t, rootResult.Summary.Cycles)
 }
 
+func TestResolvedTreeFetchTreatsEmptyOriginAsMissing(t *testing.T) {
+	sourceChild := testItem("source-child")
+	mirror := testMirror("mirror", "", sourceChild)
+	tree := NewResolvedTree([]*Item{mirror}, "test export")
+
+	result, err := tree.Fetch("None", mirror.ID, resolvedFetchOptions(1))
+	require.NoError(t, err)
+	assert.Equal(t, []string{sourceChild.ID}, itemIDs(result.Item.Children))
+	assert.Equal(t, 1, result.Summary.MissingOrigin)
+}
+
 func TestResolvedTreeFetchPrefersReachableOriginalOccurrence(t *testing.T) {
 	target := testItem("target")
 	origin := testItem("origin", target)

--- a/pkg/workflowy/resolved_tree_fetch_test.go
+++ b/pkg/workflowy/resolved_tree_fetch_test.go
@@ -1,0 +1,171 @@
+package workflowy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testItem(id string, children ...*Item) *Item {
+	return &Item{ID: id, Name: id, Data: map[string]interface{}{}, Children: children}
+}
+
+func testMirror(id, originID string, children ...*Item) *Item {
+	return &Item{
+		ID:       id,
+		Name:     id,
+		Data:     map[string]interface{}{"mirror": map[string]interface{}{"origin_id": originID}},
+		Children: children,
+	}
+}
+
+func resolvedFetchOptions(depth int) ResolveOptions {
+	return ResolveOptions{ResolveMirrors: true, Depth: depth, Operation: "get"}
+}
+
+func TestResolvedTreeFetchUsesResolvedChildRules(t *testing.T) {
+	originGrandchild := testItem("origin-grandchild")
+	originChild := testItem("origin-child", originGrandchild)
+	origin := testItem("origin", originChild)
+	sourceChild := testItem("source-child")
+	mirror := testMirror("mirror", origin.ID, sourceChild)
+	nullChild := testItem("null-child")
+	nullMirror := &Item{ID: "null-mirror", Name: "null-mirror", Data: map[string]interface{}{
+		"mirror": map[string]interface{}{"origin_id": nil},
+	}, Children: []*Item{nullChild}}
+	malformedChild := testItem("malformed-child")
+	malformedMirror := &Item{ID: "malformed-mirror", Name: "malformed-mirror", Data: map[string]interface{}{
+		"mirror": map[string]interface{}{"origin_id": 12},
+	}, Children: []*Item{malformedChild}}
+	missingChild := testItem("missing-child")
+	missingMirror := testMirror("missing-mirror", "absent-origin", missingChild)
+
+	tree := NewResolvedTree([]*Item{origin, mirror, nullMirror, malformedMirror, missingMirror}, "test export")
+
+	enabled, err := tree.Fetch("None", "None", resolvedFetchOptions(1))
+	require.NoError(t, err)
+	require.Len(t, enabled.Items, 5)
+	assert.Equal(t, []string{"origin-child"}, itemIDs(enabled.Items[0].Children))
+	assert.Equal(t, []string{"origin-child"}, itemIDs(enabled.Items[1].Children), "origin children replace source children")
+	assert.Equal(t, []string{"null-child"}, itemIDs(enabled.Items[2].Children))
+	assert.Equal(t, []string{"malformed-child"}, itemIDs(enabled.Items[3].Children))
+	assert.Equal(t, []string{"missing-child"}, itemIDs(enabled.Items[4].Children))
+	assert.Equal(t, 1, enabled.Summary.Resolved)
+	assert.Equal(t, 1, enabled.Summary.MissingOrigin)
+	assert.Equal(t, 1, enabled.Summary.MalformedMetadata)
+
+	disabled, err := tree.Fetch("None", "None", ResolveOptions{Depth: 1, Operation: "get"})
+	require.NoError(t, err)
+	require.Len(t, disabled.Items, 5)
+	assert.Equal(t, []string{"origin-child"}, itemIDs(disabled.Items[0].Children))
+	for _, item := range disabled.Items[1:] {
+		assert.Empty(t, item.Children, "%s should be a leaf", item.ID)
+	}
+
+	_, err = tree.Fetch("None", sourceChild.ID, resolvedFetchOptions(-1))
+	require.EqualError(t, err, `Cannot find Workflowy node "source-child" within resolved read scope "None" from test export`)
+}
+
+func TestResolvedTreeFetchHonorsDepthAndDoesNotMutateSource(t *testing.T) {
+	grandchild := testItem("grandchild")
+	child := testItem("child", grandchild)
+	root := testItem("root", child)
+	tree := NewResolvedTree([]*Item{root}, "test backup")
+
+	before, err := json.Marshal(root)
+	require.NoError(t, err)
+
+	depthZero, err := tree.Fetch("None", root.ID, resolvedFetchOptions(0))
+	require.NoError(t, err)
+	assert.Empty(t, depthZero.Item.Children)
+
+	finite, err := tree.Fetch("None", root.ID, resolvedFetchOptions(1))
+	require.NoError(t, err)
+	require.Len(t, finite.Item.Children, 1)
+	assert.Empty(t, finite.Item.Children[0].Children)
+
+	unlimited, err := tree.Fetch("None", root.ID, resolvedFetchOptions(-1))
+	require.NoError(t, err)
+	require.Len(t, unlimited.Item.Children[0].Children, 1)
+	assert.NotSame(t, root, unlimited.Item)
+	assert.NotSame(t, child, unlimited.Item.Children[0])
+
+	FlattenTree(unlimited.Item)
+	FilterEmptyItem(finite.Item)
+	after, err := json.Marshal(root)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(before), string(after))
+
+	rootDepthZero, err := tree.Fetch("None", "None", resolvedFetchOptions(0))
+	require.NoError(t, err)
+	require.Len(t, rootDepthZero.Items, 1)
+	assert.Empty(t, rootDepthZero.Items[0].Children)
+}
+
+func TestResolvedTreeFetchDoesNotTraverseUnrequestedCycles(t *testing.T) {
+	target := testItem("target")
+	cycleRoot := testItem("cycle-root")
+	cycleRoot.Children = []*Item{testMirror("cycle-mirror", cycleRoot.ID)}
+	tree := NewResolvedTree([]*Item{target, cycleRoot}, "test export")
+
+	result, err := tree.Fetch("None", target.ID, resolvedFetchOptions(-1))
+	require.NoError(t, err)
+	assert.Zero(t, result.Summary.Cycles)
+
+	rootResult, err := tree.Fetch("None", "None", resolvedFetchOptions(0))
+	require.NoError(t, err)
+	assert.Zero(t, rootResult.Summary.Cycles)
+}
+
+func TestResolvedTreeFetchPrefersReachableOriginalOccurrence(t *testing.T) {
+	target := testItem("target")
+	origin := testItem("origin", target)
+	firstMirror := testMirror("first-mirror", origin.ID)
+	secondMirror := testMirror("second-mirror", origin.ID)
+	tree := NewResolvedTree([]*Item{firstMirror, secondMirror, origin}, "test export")
+
+	result, err := tree.Fetch("None", target.ID, resolvedFetchOptions(0))
+	require.NoError(t, err)
+	assert.False(t, result.Occurrence.ViaMirror)
+	assert.Equal(t, []string{origin.ID}, itemIDs(result.Occurrence.Ancestors))
+}
+
+func TestResolvedTreeFetchSelectsFirstMirrorOccurrenceWhenOriginalIsOutsideScope(t *testing.T) {
+	target := testItem("target")
+	origin := testItem("origin", target)
+	firstMirror := testMirror("first-mirror", origin.ID)
+	secondMirror := testMirror("second-mirror", origin.ID)
+	scope := testItem("scope", firstMirror, secondMirror)
+	tree := NewResolvedTree([]*Item{scope, origin}, "test backup")
+
+	result, err := tree.Fetch(scope.ID, target.ID, resolvedFetchOptions(0))
+	require.NoError(t, err)
+	assert.True(t, result.Occurrence.ViaMirror)
+	assert.Equal(t, []string{scope.ID, firstMirror.ID}, itemIDs(result.Occurrence.Ancestors))
+}
+
+func TestResolvedTreeFetchCarriesSelectionPathIntoMaterialization(t *testing.T) {
+	backToOrigin := testMirror("back-to-origin", "origin")
+	target := testItem("target", backToOrigin)
+	origin := testItem("origin", target)
+	entryMirror := testMirror("entry-mirror", origin.ID)
+	scope := testItem("scope", entryMirror)
+	tree := NewResolvedTree([]*Item{scope, origin}, "test export")
+
+	result, err := tree.Fetch(scope.ID, target.ID, resolvedFetchOptions(-1))
+	require.NoError(t, err)
+	require.Len(t, result.Item.Children, 1)
+	assert.Empty(t, result.Item.Children[0].Children)
+	assert.Equal(t, 1, result.Summary.Resolved)
+	assert.Equal(t, 1, result.Summary.Cycles)
+}
+
+func itemIDs(items []*Item) []string {
+	ids := make([]string, len(items))
+	for index, item := range items {
+		ids[index] = item.ID
+	}
+	return ids
+}

--- a/pkg/workflowy/resolved_tree_traversal.go
+++ b/pkg/workflowy/resolved_tree_traversal.go
@@ -1,0 +1,353 @@
+package workflowy
+
+import (
+	"fmt"
+	"strings"
+)
+
+type nodeSelection struct {
+	occurrence NodeOccurrence
+	activeIDs  []string
+}
+
+func (occurrence NodeOccurrence) Identity() string {
+	ids := make([]string, 0, len(occurrence.Ancestors)+1)
+	for _, ancestor := range occurrence.Ancestors {
+		ids = append(ids, ancestor.ID)
+	}
+	if occurrence.Item != nil {
+		ids = append(ids, occurrence.Item.ID)
+	}
+	return strings.Join(ids, "/")
+}
+
+func (occurrence NodeOccurrence) EqualityID() string {
+	if occurrence.Item == nil {
+		return ""
+	}
+	reference := MirrorReferenceFromItem(occurrence.Item)
+	if reference.Kind == MirrorReferenceWithOrigin && reference.OriginID != "" {
+		return reference.OriginID
+	}
+	return occurrence.Item.ID
+}
+
+func (occurrence NodeOccurrence) Snapshot() NodeOccurrence {
+	snapshot := occurrence
+	snapshot.Ancestors = append([]*Item(nil), occurrence.Ancestors...)
+	return snapshot
+}
+
+func (tree *ResolvedTree) preferredSelection(
+	scope []nodeSelection,
+	readScopeID string,
+	targetID string,
+	options ResolveOptions,
+	tracker *resolutionTracker,
+) *nodeSelection {
+	if original := tree.reachableOriginalSelection(scope, readScopeID, targetID, options, tracker); original != nil {
+		return original
+	}
+
+	for _, root := range scope {
+		if found := tree.findFirstSelection(root, targetID, options, tracker); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func (tree *ResolvedTree) reachableOriginalSelection(
+	scope []nodeSelection,
+	readScopeID string,
+	targetID string,
+	options ResolveOptions,
+	tracker *resolutionTracker,
+) *nodeSelection {
+	targetNode := tree.index[targetID]
+	if targetNode == nil {
+		return nil
+	}
+
+	path := sourcePath(targetNode)
+	if readScopeID != "" && readScopeID != "None" {
+		scopeIndex := -1
+		for index, item := range path {
+			if item.ID == readScopeID {
+				scopeIndex = index
+				break
+			}
+		}
+		if scopeIndex < 0 || len(scope) != 1 || scope[0].occurrence.ViaMirror {
+			return nil
+		}
+		path = path[scopeIndex:]
+	}
+
+	if len(path) == 0 {
+		return nil
+	}
+	selection := nodeSelection{
+		occurrence: NodeOccurrence{
+			Item:      path[0],
+			Ancestors: append([]*Item(nil), scopeAncestors(scope, path[0])...),
+			ViaMirror: scopeViaMirror(scope, path[0]),
+		},
+		activeIDs: append([]string(nil), scopeActiveIDs(scope, path[0])...),
+	}
+	if len(selection.activeIDs) == 0 {
+		selection.activeIDs = []string{path[0].ID}
+	}
+	tracker.observe(selection)
+
+	for index := 0; index < len(path)-1; index++ {
+		parent := selection.occurrence.Item
+		children, hiddenActive, childViaMirror := tree.resolvedChildren(selection, options, tracker)
+		next := path[index+1]
+		if !containsItemPointer(children, next) {
+			return nil
+		}
+		selection.occurrence.Ancestors = append(selection.occurrence.Ancestors, parent)
+		selection.occurrence.Item = next
+		selection.occurrence.ViaMirror = childViaMirror || MirrorReferenceFromItem(next).IsMirror()
+		selection.activeIDs = append(append([]string(nil), hiddenActive...), next.ID)
+		tracker.observe(selection)
+	}
+
+	if selection.occurrence.ViaMirror {
+		return nil
+	}
+	selection.occurrence.Ancestors = append([]*Item(nil), selection.occurrence.Ancestors...)
+	selection.activeIDs = append([]string(nil), selection.activeIDs...)
+	return &selection
+}
+
+func scopeAncestors(scope []nodeSelection, first *Item) []*Item {
+	if len(scope) == 1 && scope[0].occurrence.Item == first {
+		return scope[0].occurrence.Ancestors
+	}
+	return nil
+}
+
+func scopeViaMirror(scope []nodeSelection, first *Item) bool {
+	return len(scope) == 1 && scope[0].occurrence.Item == first && scope[0].occurrence.ViaMirror
+}
+
+func scopeActiveIDs(scope []nodeSelection, first *Item) []string {
+	if len(scope) == 1 && scope[0].occurrence.Item == first {
+		return scope[0].activeIDs
+	}
+	return nil
+}
+
+func sourcePath(node *sourceNode) []*Item {
+	reversed := make([]*Item, 0)
+	for current := node; current != nil; current = current.parent {
+		reversed = append(reversed, current.item)
+	}
+	path := make([]*Item, len(reversed))
+	for index := range reversed {
+		path[len(reversed)-1-index] = reversed[index]
+	}
+	return path
+}
+
+func containsItemPointer(items []*Item, target *Item) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (tree *ResolvedTree) findFirstSelection(
+	selection nodeSelection,
+	targetID string,
+	options ResolveOptions,
+	tracker *resolutionTracker,
+) *nodeSelection {
+	tracker.observe(selection)
+	if selection.occurrence.Item.ID == targetID {
+		found := selection
+		found.occurrence = selection.occurrence.Snapshot()
+		found.activeIDs = append([]string(nil), selection.activeIDs...)
+		return &found
+	}
+
+	children, activeIDs, childViaMirror := tree.resolvedChildren(selection, options, tracker)
+	for _, child := range children {
+		childSelection := nodeSelection{
+			occurrence: NodeOccurrence{
+				Item:      child,
+				Ancestors: append(selection.occurrence.Ancestors, selection.occurrence.Item),
+				ViaMirror: childViaMirror || MirrorReferenceFromItem(child).IsMirror(),
+			},
+			activeIDs: append(activeIDs, child.ID),
+		}
+		if found := tree.findFirstSelection(childSelection, targetID, options, tracker); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func (tree *ResolvedTree) materialize(
+	selection nodeSelection,
+	depth int,
+	options ResolveOptions,
+	tracker *resolutionTracker,
+) *Item {
+	tracker.observe(selection)
+	item := cloneItemWithoutChildren(selection.occurrence.Item)
+	tracker.retain(selection)
+	if depth == 0 {
+		return item
+	}
+
+	children, activeIDs, childViaMirror := tree.resolvedChildren(selection, options, tracker)
+	childDepth := depth
+	if childDepth > 0 {
+		childDepth--
+	}
+	item.Children = make([]*Item, 0, len(children))
+	for _, child := range children {
+		childSelection := nodeSelection{
+			occurrence: NodeOccurrence{
+				Item:      child,
+				Ancestors: append(selection.occurrence.Ancestors, selection.occurrence.Item),
+				ViaMirror: childViaMirror || MirrorReferenceFromItem(child).IsMirror(),
+			},
+			activeIDs: append(activeIDs, child.ID),
+		}
+		item.Children = append(item.Children, tree.materialize(childSelection, childDepth, options, tracker))
+	}
+	return item
+}
+
+func (tree *ResolvedTree) Visit(
+	readScopeID, targetID string,
+	options ResolveOptions,
+	visitor OccurrenceVisitor,
+) (MirrorResolutionSummary, error) {
+	tracker := newResolutionTracker(tree, readScopeID, targetID, options)
+	defer tracker.finish()
+	scope, err := tree.readScope(readScopeID, options, tracker)
+	if err != nil {
+		return tracker.summary, err
+	}
+
+	if targetID != "" && targetID != "None" {
+		selection := tree.preferredSelection(scope, readScopeID, targetID, options, tracker)
+		if selection == nil {
+			return tracker.summary, fmt.Errorf(
+				"Cannot find Workflowy node %q within resolved read scope %q from %s",
+				targetID,
+				readScopeID,
+				tree.sourceLabel,
+			)
+		}
+		scope = []nodeSelection{*selection}
+	}
+
+	for _, selection := range scope {
+		if err := tree.visitSelection(selection, options.Depth, options, tracker, visitor); err != nil {
+			return tracker.summary, err
+		}
+	}
+	return tracker.summary, nil
+}
+
+func (tree *ResolvedTree) visitSelection(
+	selection nodeSelection,
+	depth int,
+	options ResolveOptions,
+	tracker *resolutionTracker,
+	visitor OccurrenceVisitor,
+) error {
+	tracker.observe(selection)
+	visitResult, err := visitor(selection.occurrence)
+	if err != nil {
+		return fmt.Errorf(
+			"Cannot visit Workflowy node %q during %s from %s: %w",
+			selection.occurrence.Item.ID,
+			options.Operation,
+			tree.sourceLabel,
+			err,
+		)
+	}
+	tracker.retainedOccurrences = visitResult.RetainedOccurrences
+	if depth == 0 {
+		return nil
+	}
+
+	children, activeIDs, childViaMirror := tree.resolvedChildren(selection, options, tracker)
+	childDepth := depth
+	if childDepth > 0 {
+		childDepth--
+	}
+	for _, child := range children {
+		ancestorCount := len(selection.occurrence.Ancestors)
+		selection.occurrence.Ancestors = append(selection.occurrence.Ancestors, selection.occurrence.Item)
+		childSelection := nodeSelection{
+			occurrence: NodeOccurrence{
+				Item:      child,
+				Ancestors: selection.occurrence.Ancestors,
+				ViaMirror: childViaMirror || MirrorReferenceFromItem(child).IsMirror(),
+			},
+			activeIDs: append(activeIDs, child.ID),
+		}
+		if err := tree.visitSelection(childSelection, childDepth, options, tracker, visitor); err != nil {
+			return err
+		}
+		selection.occurrence.Ancestors = selection.occurrence.Ancestors[:ancestorCount]
+	}
+	return nil
+}
+
+func (tree *ResolvedTree) resolvedChildren(
+	selection nodeSelection,
+	options ResolveOptions,
+	tracker *resolutionTracker,
+) ([]*Item, []string, bool) {
+	item := selection.occurrence.Item
+	reference := MirrorReferenceFromItem(item)
+	if !reference.IsMirror() {
+		return item.Children, selection.activeIDs, selection.occurrence.ViaMirror
+	}
+	if !options.ResolveMirrors {
+		return nil, selection.activeIDs, true
+	}
+
+	switch reference.Kind {
+	case MirrorReferenceNullOrigin:
+		return item.Children, selection.activeIDs, true
+	case MirrorReferenceMalformed:
+		tracker.record("malformed", selection, reference)
+		return item.Children, selection.activeIDs, true
+	case MirrorReferenceWithOrigin:
+		origin := tree.index[reference.OriginID]
+		if origin == nil {
+			tracker.record("missing", selection, reference)
+			return item.Children, selection.activeIDs, true
+		}
+		if containsString(selection.activeIDs, reference.OriginID) {
+			tracker.record("cycle", selection, reference)
+			return nil, selection.activeIDs, true
+		}
+		tracker.record("resolved", selection, reference)
+		activeIDs := append(selection.activeIDs, reference.OriginID)
+		return origin.item.Children, activeIDs, true
+	default:
+		return item.Children, selection.activeIDs, selection.occurrence.ViaMirror
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/workflowy/resolved_tree_traversal.go
+++ b/pkg/workflowy/resolved_tree_traversal.go
@@ -8,6 +8,7 @@ import (
 type nodeSelection struct {
 	occurrence NodeOccurrence
 	activeIDs  []string
+	observed   bool
 }
 
 func (occurrence NodeOccurrence) Identity() string {
@@ -45,7 +46,7 @@ func (tree *ResolvedTree) preferredSelection(
 	options ResolveOptions,
 	tracker *resolutionTracker,
 ) *nodeSelection {
-	if original := tree.reachableOriginalSelection(scope, readScopeID, targetID, options, tracker); original != nil {
+	if original := tree.reachableOriginalSelection(scope, readScopeID, targetID, options); original != nil {
 		return original
 	}
 
@@ -62,7 +63,6 @@ func (tree *ResolvedTree) reachableOriginalSelection(
 	readScopeID string,
 	targetID string,
 	options ResolveOptions,
-	tracker *resolutionTracker,
 ) *nodeSelection {
 	targetNode := tree.index[targetID]
 	if targetNode == nil {
@@ -98,11 +98,9 @@ func (tree *ResolvedTree) reachableOriginalSelection(
 	if len(selection.activeIDs) == 0 {
 		selection.activeIDs = []string{path[0].ID}
 	}
-	tracker.observe(selection)
-
 	for index := 0; index < len(path)-1; index++ {
 		parent := selection.occurrence.Item
-		children, hiddenActive, childViaMirror := tree.resolvedChildren(selection, options, tracker)
+		children, hiddenActive, childViaMirror := tree.resolvedChildren(selection, options, nil)
 		next := path[index+1]
 		if !containsItemPointer(children, next) {
 			return nil
@@ -111,7 +109,6 @@ func (tree *ResolvedTree) reachableOriginalSelection(
 		selection.occurrence.Item = next
 		selection.occurrence.ViaMirror = childViaMirror || MirrorReferenceFromItem(next).IsMirror()
 		selection.activeIDs = append(append([]string(nil), hiddenActive...), next.ID)
-		tracker.observe(selection)
 	}
 
 	if selection.occurrence.ViaMirror {
@@ -167,7 +164,10 @@ func (tree *ResolvedTree) findFirstSelection(
 	options ResolveOptions,
 	tracker *resolutionTracker,
 ) *nodeSelection {
-	tracker.observe(selection)
+	if !selection.observed {
+		tracker.observe(selection)
+		selection.observed = true
+	}
 	if selection.occurrence.Item.ID == targetID {
 		found := selection
 		found.occurrence = selection.occurrence.Snapshot()
@@ -198,9 +198,12 @@ func (tree *ResolvedTree) materialize(
 	options ResolveOptions,
 	tracker *resolutionTracker,
 ) *Item {
-	tracker.observe(selection)
+	if !selection.observed {
+		tracker.observe(selection)
+		selection.observed = true
+	}
 	item := cloneItemWithoutChildren(selection.occurrence.Item)
-	tracker.retain(selection)
+	tracker.retain()
 	if depth == 0 {
 		return item
 	}
@@ -265,7 +268,10 @@ func (tree *ResolvedTree) visitSelection(
 	tracker *resolutionTracker,
 	visitor OccurrenceVisitor,
 ) error {
-	tracker.observe(selection)
+	if !selection.observed {
+		tracker.observe(selection)
+		selection.observed = true
+	}
 	visitResult, err := visitor(selection.occurrence)
 	if err != nil {
 		return fmt.Errorf(
@@ -323,19 +329,33 @@ func (tree *ResolvedTree) resolvedChildren(
 	case MirrorReferenceNullOrigin:
 		return item.Children, selection.activeIDs, true
 	case MirrorReferenceMalformed:
-		tracker.record("malformed", selection, reference)
+		if tracker != nil {
+			tracker.record("malformed", selection, reference)
+		}
 		return item.Children, selection.activeIDs, true
 	case MirrorReferenceWithOrigin:
+		if reference.OriginID == "" {
+			if tracker != nil {
+				tracker.record("missing", selection, reference)
+			}
+			return item.Children, selection.activeIDs, true
+		}
 		origin := tree.index[reference.OriginID]
 		if origin == nil {
-			tracker.record("missing", selection, reference)
+			if tracker != nil {
+				tracker.record("missing", selection, reference)
+			}
 			return item.Children, selection.activeIDs, true
 		}
 		if containsString(selection.activeIDs, reference.OriginID) {
-			tracker.record("cycle", selection, reference)
+			if tracker != nil {
+				tracker.record("cycle", selection, reference)
+			}
 			return nil, selection.activeIDs, true
 		}
-		tracker.record("resolved", selection, reference)
+		if tracker != nil {
+			tracker.record("resolved", selection, reference)
+		}
 		activeIDs := append(selection.activeIDs, reference.OriginID)
 		return origin.item.Children, activeIDs, true
 	default:

--- a/pkg/workflowy/resolved_tree_visit_test.go
+++ b/pkg/workflowy/resolved_tree_visit_test.go
@@ -109,6 +109,44 @@ func TestResolvedTreeVisitDoesNotGloballySuppressIndependentOccurrences(t *testi
 	assert.Equal(t, 3, visits)
 }
 
+func TestResolvedTreeVisitAllowsLaterPathWithDifferentCycleBoundary(t *testing.T) {
+	backToRoot := testMirror("back-to-root", "root")
+	intermediate := testItem("intermediate", backToRoot)
+	root := testItem("root", intermediate)
+	entry := testMirror("entry", intermediate.ID)
+	tree := NewResolvedTree([]*Item{root, entry}, "test export")
+
+	var identities []string
+	summary, err := tree.Visit("None", "None", resolvedFetchOptions(-1), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		identities = append(identities, occurrence.Identity())
+		return OccurrenceVisitResult{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, summary.Cycles)
+	assert.Contains(t, identities, "root/intermediate/back-to-root")
+	assert.NotContains(t, identities, "root/intermediate/back-to-root/intermediate")
+	assert.Contains(t, identities, "entry/back-to-root/intermediate")
+	assert.Contains(t, identities, "entry/back-to-root/intermediate/back-to-root")
+}
+
+func TestResolvedTreeVisitStopsNestedMirrorCycle(t *testing.T) {
+	backToFirst := testMirror("back-to-first", "first")
+	second := testItem("second", backToFirst)
+	toSecond := testMirror("to-second", second.ID)
+	first := testItem("first", toSecond)
+	tree := NewResolvedTree([]*Item{first, second}, "test backup")
+
+	var identities []string
+	summary, err := tree.Visit("first", "None", resolvedFetchOptions(-1), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		identities = append(identities, occurrence.Identity())
+		return OccurrenceVisitResult{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.Resolved)
+	assert.Equal(t, 1, summary.Cycles)
+	assert.Equal(t, []string{"first", "first/to-second", "first/to-second/back-to-first"}, identities)
+}
+
 func TestResolvedTreeVisitStopsOnVisitorErrorWithContext(t *testing.T) {
 	tree := NewResolvedTree([]*Item{testItem("root", testItem("child"))}, "test export")
 	want := errors.New("matcher failed")

--- a/pkg/workflowy/resolved_tree_visit_test.go
+++ b/pkg/workflowy/resolved_tree_visit_test.go
@@ -1,0 +1,125 @@
+package workflowy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeOccurrenceIdentityEqualityAndSnapshot(t *testing.T) {
+	ancestor := testItem("ancestor")
+	mirror := testMirror("mirror", "origin")
+	occurrence := NodeOccurrence{Item: mirror, Ancestors: []*Item{ancestor}, ViaMirror: true}
+
+	assert.Equal(t, "ancestor/mirror", occurrence.Identity())
+	assert.Equal(t, "origin", occurrence.EqualityID())
+
+	snapshot := occurrence.Snapshot()
+	occurrence.Ancestors[0] = testItem("changed")
+	assert.Equal(t, "ancestor/mirror", snapshot.Identity())
+	assert.Equal(t, "plain", (NodeOccurrence{Item: testItem("plain")}).EqualityID())
+}
+
+func TestResolvedTreeVisitReportsPathsAndMirrorDescendants(t *testing.T) {
+	grandchild := testItem("grandchild")
+	child := testItem("child", grandchild)
+	origin := testItem("origin", child)
+	mirror := testMirror("mirror", origin.ID)
+	tree := NewResolvedTree([]*Item{origin, mirror}, "test export")
+
+	occurrences := make([]NodeOccurrence, 0)
+	summary, err := tree.Visit("None", "None", resolvedFetchOptions(-1), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		occurrences = append(occurrences, occurrence.Snapshot())
+		return OccurrenceVisitResult{RetainedOccurrences: len(occurrences)}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.Resolved)
+
+	byIdentity := make(map[string]NodeOccurrence)
+	for _, occurrence := range occurrences {
+		byIdentity[occurrence.Identity()] = occurrence
+	}
+	assert.False(t, byIdentity["origin/child"].ViaMirror)
+	assert.True(t, byIdentity["mirror/child"].ViaMirror)
+	assert.True(t, byIdentity["mirror/child/grandchild"].ViaMirror)
+	assert.Equal(t, []string{"mirror", "child"}, itemIDs(byIdentity["mirror/child/grandchild"].Ancestors))
+}
+
+func TestResolvedTreeVisitUsesPreferredTargetOccurrence(t *testing.T) {
+	target := testItem("target", testItem("descendant"))
+	origin := testItem("origin", target)
+	firstMirror := testMirror("first-mirror", origin.ID)
+	secondMirror := testMirror("second-mirror", origin.ID)
+	tree := NewResolvedTree([]*Item{firstMirror, secondMirror, origin}, "test export")
+
+	var identities []string
+	_, err := tree.Visit("None", target.ID, resolvedFetchOptions(-1), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		identities = append(identities, occurrence.Identity())
+		return OccurrenceVisitResult{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"origin/target", "origin/target/descendant"}, identities)
+
+	scope := testItem("scope", firstMirror, secondMirror)
+	scopedTree := NewResolvedTree([]*Item{scope, origin}, "test export")
+	identities = nil
+	_, err = scopedTree.Visit(scope.ID, target.ID, resolvedFetchOptions(0), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		identities = append(identities, occurrence.Identity())
+		return OccurrenceVisitResult{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"scope/first-mirror/target"}, identities)
+}
+
+func TestResolvedTreeVisitStopsCyclesPerBranch(t *testing.T) {
+	selfMirror := testMirror("self-mirror", "origin")
+	origin := testItem("origin", selfMirror)
+	firstEntry := testMirror("first-entry", origin.ID)
+	secondEntry := testMirror("second-entry", origin.ID)
+	tree := NewResolvedTree([]*Item{origin, firstEntry, secondEntry}, "test backup")
+
+	var identities []string
+	summary, err := tree.Visit("None", "None", resolvedFetchOptions(-1), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		identities = append(identities, occurrence.Identity())
+		return OccurrenceVisitResult{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, summary.Cycles)
+	assert.Contains(t, identities, "origin/self-mirror")
+	assert.Contains(t, identities, "first-entry/self-mirror")
+	assert.Contains(t, identities, "second-entry/self-mirror")
+	assert.NotContains(t, identities, "origin/self-mirror/self-mirror")
+}
+
+func TestResolvedTreeVisitDoesNotGloballySuppressIndependentOccurrences(t *testing.T) {
+	child := testItem("child")
+	origin := testItem("origin", child)
+	tree := NewResolvedTree([]*Item{testMirror("one", origin.ID), testMirror("two", origin.ID), origin}, "test export")
+
+	visits := 0
+	_, err := tree.Visit("None", "None", resolvedFetchOptions(-1), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		if occurrence.Item.ID == child.ID {
+			visits++
+		}
+		return OccurrenceVisitResult{}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, visits)
+}
+
+func TestResolvedTreeVisitStopsOnVisitorErrorWithContext(t *testing.T) {
+	tree := NewResolvedTree([]*Item{testItem("root", testItem("child"))}, "test export")
+	want := errors.New("matcher failed")
+
+	_, err := tree.Visit("None", "None", resolvedFetchOptions(-1), func(occurrence NodeOccurrence) (OccurrenceVisitResult, error) {
+		if occurrence.Item.ID == "child" {
+			return OccurrenceVisitResult{}, want
+		}
+		return OccurrenceVisitResult{}, nil
+	})
+
+	require.ErrorIs(t, err, want)
+	assert.EqualError(t, err, `Cannot visit Workflowy node "child" during get from test export: matcher failed`)
+}

--- a/pkg/workflowy/workflowy.go
+++ b/pkg/workflowy/workflowy.go
@@ -205,13 +205,33 @@ func ResolveAPIKey(apiKeyFile, defaultAPIKeyFile string) (client.Option, error) 
 // WorkflowyClient wraps the generic Client with Workflowy-specific methods
 type WorkflowyClient struct {
 	*client.Client
-	opts []client.Option
+	opts            []client.Option
+	exportCachePath string
 }
 
 // NewWorkflowyClient creates a new Workflowy API client
-func NewWorkflowyClient(opts ...client.Option) *WorkflowyClient {
-	c := client.New("https://workflowy.com/api/v1", opts...)
-	return &WorkflowyClient{Client: c, opts: opts}
+func NewWorkflowyClient(deployment APIDeployment, opts ...client.Option) (*WorkflowyClient, error) {
+	baseURL, err := deployment.BaseURL()
+	if err != nil {
+		return nil, err
+	}
+
+	cacheFile, err := deployment.exportCacheFile()
+	if err != nil {
+		return nil, err
+	}
+
+	exportCachePath, err := cache.GetCachePath(cacheFile)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug("creating Workflowy client", "api", deployment, "base_url", baseURL, "export_cache_path", exportCachePath)
+	return &WorkflowyClient{
+		Client:          client.New(baseURL, opts...),
+		opts:            opts,
+		exportCachePath: exportCachePath,
+	}, nil
 }
 
 // Item represents a Workflowy item with all its properties
@@ -702,7 +722,7 @@ func sortItemsByPriorityRecursive(item *Item) {
 // forceRefresh bypasses cache and fetches fresh data
 func (wc *WorkflowyClient) ExportNodesWithCache(ctx context.Context, forceRefresh bool) (*ExportNodesResponse, error) {
 	// Try to read cache first
-	cachedData, err := cache.ReadExportCache()
+	cachedData, err := cache.ReadExportCache(wc.exportCachePath)
 	if err != nil {
 		slog.Warn("cannot read cache, will fetch from API", "error", err)
 	}
@@ -748,7 +768,7 @@ func (wc *WorkflowyClient) ExportNodesWithCache(ctx context.Context, forceRefres
 	}
 
 	// Write to cache
-	if err := cache.WriteExportCache(resp); err != nil {
+	if err := cache.WriteExportCache(wc.exportCachePath, resp); err != nil {
 		slog.Warn("cannot write cache (continuing anyway)", "error", err)
 	}
 

--- a/pkg/workflowy/workflowy.go
+++ b/pkg/workflowy/workflowy.go
@@ -207,6 +207,7 @@ type WorkflowyClient struct {
 	*client.Client
 	opts            []client.Option
 	exportCachePath string
+	deployment      APIDeployment
 }
 
 // NewWorkflowyClient creates a new Workflowy API client
@@ -233,6 +234,7 @@ func NewWorkflowyClient(deployment APIDeployment, opts ...client.Option) (*Workf
 		Client:          client.New(baseURL, clientOptions...),
 		opts:            opts,
 		exportCachePath: exportCachePath,
+		deployment:      deployment,
 	}, nil
 }
 
@@ -353,70 +355,6 @@ func (wc *WorkflowyClient) ListChildren(ctx context.Context, itemID string) (*Li
 	}
 
 	return &resp, nil
-}
-
-// ListChildrenRecursive retrieves children recursively, building a complete tree
-// Use itemID "None" to get the entire outline tree
-// Uses default depth of 5 levels
-func (wc *WorkflowyClient) ListChildrenRecursive(ctx context.Context, itemID string) (*ListChildrenResponse, error) {
-	return wc.ListChildrenRecursiveWithDepth(ctx, itemID, 5)
-}
-
-// ListChildrenRecursiveWithDepth retrieves children recursively up to specified depth
-// Use itemID "None" to get the entire outline tree
-// depth parameter controls how many levels deep to fetch (0 = no children, 1 = direct children only, etc.)
-func (wc *WorkflowyClient) ListChildrenRecursiveWithDepth(ctx context.Context, itemID string, depth int) (*ListChildrenResponse, error) {
-	// If depth is 0, return empty response without making any API calls
-	if depth <= 0 {
-		return &ListChildrenResponse{Items: []*Item{}}, nil
-	}
-
-	resp, err := wc.ListChildren(ctx, itemID)
-	if err != nil {
-		return nil, err
-	}
-
-	// If depth > 1, recursively fetch children for each item
-	if depth > 1 {
-		for _, item := range resp.Items {
-			err := wc.fetchChildrenRecursively(ctx, item, depth-1)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return resp, nil
-}
-
-// fetchChildrenRecursively is a helper function to recursively populate children
-// depth parameter controls how many more levels deep to fetch
-func (wc *WorkflowyClient) fetchChildrenRecursively(ctx context.Context, item *Item, depth int) error {
-	slog.Debug("fetching children recursively", "item_id", item.ID, "depth", depth)
-
-	// Stop recursion if depth is 0 or negative
-	if depth <= 0 {
-		return nil
-	}
-
-	childrenResp, err := wc.ListChildren(ctx, item.ID)
-	if err != nil {
-		return err
-	}
-
-	if len(childrenResp.Items) > 0 {
-		item.Children = childrenResp.Items
-
-		// Recursively fetch children for each child, reducing depth by 1
-		for _, child := range item.Children {
-			err := wc.fetchChildrenRecursively(ctx, child, depth-1)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
 }
 
 // CreateNode creates a new node in Workflowy

--- a/pkg/workflowy/workflowy.go
+++ b/pkg/workflowy/workflowy.go
@@ -50,7 +50,7 @@ func SanitizeNodeID(id string) string {
 	if id == "" || id == "None" {
 		return id
 	}
-	id = strings.TrimPrefix(id, "https://workflowy.com/#/")
+	id = nodeIDFromURL(id)
 	var result strings.Builder
 	for _, r := range id {
 		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') || r == '-' {
@@ -227,8 +227,10 @@ func NewWorkflowyClient(deployment APIDeployment, opts ...client.Option) (*Workf
 	}
 
 	slog.Debug("creating Workflowy client", "api", deployment, "base_url", baseURL, "export_cache_path", exportCachePath)
+	clientOptions := append([]client.Option(nil), opts...)
+	clientOptions = append(clientOptions, client.WithLogAttributes(slog.String("api", string(deployment))))
 	return &WorkflowyClient{
-		Client:          client.New(baseURL, opts...),
+		Client:          client.New(baseURL, clientOptions...),
 		opts:            opts,
 		exportCachePath: exportCachePath,
 	}, nil

--- a/pkg/workflowy/workflowy_test.go
+++ b/pkg/workflowy/workflowy_test.go
@@ -553,3 +553,9 @@ func TestSanitizeNodeID(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeNodeIDStripsBetaWorkflowyURL(t *testing.T) {
+	const nodeID = "12345678-1234-1234-1234-123456789abc"
+
+	assert.Equal(t, nodeID, SanitizeNodeID("https://beta.workflowy.com/#/"+nodeID))
+}

--- a/pkg/workflowy/workflowy_test.go
+++ b/pkg/workflowy/workflowy_test.go
@@ -245,6 +245,12 @@ func TestWorkflowyClient_ListChildrenRecursiveWithDepth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify it's a GET request
 		assert.Equal(t, "GET", r.Method)
+		if r.URL.Path == "/nodes/root" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(GetItemResponse{Node: Item{ID: "root", Name: "Root"}})
+			return
+		}
 
 		// Extract parent_id from query string
 		parentID := r.URL.Query().Get("parent_id")
@@ -342,6 +348,10 @@ func TestWorkflowyClient_ListChildrenRecursive_DefaultDepth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == "/nodes/root" {
+			json.NewEncoder(w).Encode(GetItemResponse{Node: Item{ID: "root", Name: "Root"}})
+			return
+		}
 		json.NewEncoder(w).Encode(ListChildrenResponse{
 			Items: []*Item{
 				{ID: "child1", Name: "Child 1"},

--- a/pkg/workflowy/workflowy_test.go
+++ b/pkg/workflowy/workflowy_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,6 +13,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewWorkflowyClientForAPI(t *testing.T) {
+	homeDirectory := t.TempDir()
+	t.Setenv("HOME", homeDirectory)
+
+	productionClient, err := NewWorkflowyClient(ProductionAPI)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(homeDirectory, ".workflowy/export-cache.json"), productionClient.exportCachePath)
+
+	betaClient, err := NewWorkflowyClient(BetaAPI)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(homeDirectory, ".workflowy/export-cache-beta.json"), betaClient.exportCachePath)
+}
 
 func TestWorkflowyClient_GetItem(t *testing.T) {
 	tests := []struct {

--- a/scripts/curl-workflowy
+++ b/scripts/curl-workflowy
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -lt 1 ]; then
+	echo "usage: $0 PATH [curl args...]" >&2
+	exit 1
+fi
+
+path=$1
+shift
+
+api_key_file="${HOME}/.workflowy/api.key"
+
+if [ ! -f "$api_key_file" ]; then
+	echo "api key file not found: $api_key_file" >&2
+	exit 1
+fi
+
+api_key=$(tr -d '\r\n' < "$api_key_file")
+
+if [ -z "$api_key" ]; then
+	echo "api key file is empty: $api_key_file" >&2
+	exit 1
+fi
+
+base_url="https://beta.workflowy.com/api/v1"
+
+set -x
+
+exec curl -sS -G -H "Authorization: Bearer $api_key" "$@" "$base_url$path"

--- a/scripts/curl-workflowy
+++ b/scripts/curl-workflowy
@@ -24,8 +24,6 @@ if [ -z "$api_key" ]; then
 	exit 1
 fi
 
-base_url="https://beta.workflowy.com/api/v1"
+base_url="https://workflowy.com/api/v1"
 
-set -x
-
-exec curl -sS -G -H "Authorization: Bearer $api_key" "$@" "$base_url$path"
+exec curl -sS -H "Authorization: Bearer $api_key" "$@" "$base_url$path"

--- a/scripts/curl_workflowy_test.go
+++ b/scripts/curl_workflowy_test.go
@@ -1,0 +1,56 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurlWorkflowy_UsesDefaultAPIKeyAndPassesCurlFlags(t *testing.T) {
+	root, err := filepath.Abs("..")
+	require.NoError(t, err)
+
+	home := t.TempDir()
+	apiKeyDir := filepath.Join(home, ".workflowy")
+	require.NoError(t, os.MkdirAll(apiKeyDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(apiKeyDir, "api.key"), []byte("test-api-key\n"), 0o600))
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	argsFile := filepath.Join(t.TempDir(), "curl-args.txt")
+	curlStub := filepath.Join(binDir, "curl")
+	stub := "#!/bin/sh\nprintf '%s\n' \"$@\" > \"$CURL_ARGS_FILE\"\nprintf 'stub response\\n'"
+	require.NoError(t, os.WriteFile(curlStub, []byte(stub), 0o755))
+
+	cmd := exec.Command(filepath.Join(root, "scripts", "curl-workflowy"), "/nodes/test-id", "-X", "POST", "-d", `{"name":"Test"}`)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"CURL_ARGS_FILE="+argsFile,
+	)
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	assert.Equal(t, "stub response\n", string(output))
+
+	argsData, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+
+	args := strings.Split(strings.TrimSpace(string(argsData)), "\n")
+	assert.Equal(t, []string{
+		"-sS",
+		"-H",
+		"Authorization: Bearer test-api-key",
+		"-X",
+		"POST",
+		"-d",
+		`{"name":"Test"}`,
+		"https://workflowy.com/api/v1/nodes/test-id",
+	}, args)
+}

--- a/test/api_read.bats
+++ b/test/api_read.bats
@@ -42,16 +42,18 @@ setup() {
 
 @test "get root from production API" {
     require_jq
-    run run_workflowy get --api=production --method=get --depth=0 --format=json --log=error
+    run run_workflowy get --api=production --method=get --depth=1 --format=json --log=error
     [ "$status" -eq 0 ]
     assert_valid_json "$output"
+    [ "$(jq '.nodes | length' <<<"$output")" -gt 0 ]
 }
 
 @test "get root from beta API" {
     require_jq
-    run run_workflowy get --api=beta --method=get --depth=0 --format=json --log=error
+    run run_workflowy get --api=beta --method=get --depth=1 --format=json --log=error
     [ "$status" -eq 0 ]
     assert_valid_json "$output"
+    [ "$(jq '.nodes | length' <<<"$output")" -gt 0 ]
 }
 
 # List Command Tests

--- a/test/api_read.bats
+++ b/test/api_read.bats
@@ -40,6 +40,20 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "get root from production API" {
+    require_jq
+    run run_workflowy get --api=production --method=get --depth=0 --format=json --log=error
+    [ "$status" -eq 0 ]
+    assert_valid_json "$output"
+}
+
+@test "get root from beta API" {
+    require_jq
+    run run_workflowy get --api=beta --method=get --depth=0 --format=json --log=error
+    [ "$status" -eq 0 ]
+    assert_valid_json "$output"
+}
+
 # List Command Tests
 
 @test "list returns flat list of items" {


### PR DESCRIPTION
## Summary

- add production and beta API selection across the CLI and MCP interfaces
- add debug logging for Workflowy HTTP operations and a curl troubleshooting helper
- document the mirror-support architecture and implementation plan
- normalize beta and backup mirror metadata into one model
- add on-demand resolved-tree fetch and streaming traversal without materializing or retaining every occurrence
- make direct API recursion mirror-aware, including disabled resolution, branch-local cycle detection, and contextual diagnostics

## Design notes

Mirror traversal retains only active branch state plus consolidated cycle diagnostics. It does not build a fully resolved tree or keep identity strings for every visited occurrence. Export and backup traversal resolve available origins locally; direct API traversal uses the selected server response while applying the same metadata and cycle rules.

This PR contains the completed foundation. Follow-up work will wire mirror resolution into CLI/MCP get, list, and search handlers and add mirror creation commands.

## Validation

- `just test`
- `go vet ./...`
- `go test -race ./pkg/workflowy -count=1`
- aggregate statement coverage: 47.6%, up from the 42.6% baseline

The completed chunk passed separate specification and code-quality reviews.